### PR TITLE
Fix PHPStan excludes for `sites/*/files` descendants

### DIFF
--- a/commands/web/phpstan
+++ b/commands/web/phpstan
@@ -181,8 +181,8 @@ DEFAULT_PATHS=()
 EXCLUDE_PATHS=(
   "${DOCROOT}/modules/contrib"
   "${DOCROOT}/themes/contrib"
-  "${DOCROOT}/sites/*/files"
-  "sites/*/files"
+  "${DOCROOT}/sites/*/files/*"
+  "sites/*/files/*"
 )
 # Prefer explicit project configs before falling back to CI template config.
 for config_file in phpstan.neon phpstan.neon.dist phpstan.dist.neon; do

--- a/drupal-code-quality/config-amendments/phpstan.dcq.neon
+++ b/drupal-code-quality/config-amendments/phpstan.dcq.neon
@@ -9,7 +9,7 @@ parameters:
         - __DOCROOT__/sites
     excludePaths:
         analyseAndScan:
-            - __DOCROOT__/sites/*/files
+            - __DOCROOT__/sites/*/files/*
 
 # Baseline guidance:
 # - Generate a baseline with: ddev phpstan --generate-baseline

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -968,7 +968,7 @@ PY
   assert_success
   run grep -q "docroot/sites" phpstan.neon
   assert_success
-  run grep -q "docroot/sites/\*/files" phpstan.neon
+  run grep -q "docroot/sites/\*/files/\*" phpstan.neon
   assert_success
 }
 
@@ -1010,8 +1010,31 @@ PY
   # Check for excludePaths
   run grep -q "excludePaths:" phpstan.neon
   assert_success
-  run grep -q "web/sites/\*/files" phpstan.neon
+  run grep -q "web/sites/\*/files/\*" phpstan.neon
   assert_success
+}
+
+@test "phpstan excludes nested files directory descendants" {
+  set -u -o pipefail
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  mkdir -p web/sites/default/files/php/twig/test-subdir
+  cat > web/sites/default/files/php/twig/test-subdir/should-not-scan.php <<'PHP'
+<?php
+
+final class DcqPhpstanExcludeProbe {}
+PHP
+
+  run ddev phpstan analyse --debug -c phpstan.neon web/sites
+  assert_failure
+
+  case "$output" in
+    *"test-subdir/should-not-scan.php"*)
+      echo "Expected phpstan excludePaths to skip files descendants under web/sites/*/files."
+      return 1
+      ;;
+  esac
 }
 
 @test "cspell config is expanded during installation" {


### PR DESCRIPTION
## The Issue

- Fixes #7

PHPStan was scanning generated runtime files under `web/sites/default/files/...` on Drupal CMS installs, producing a large amount of noisy output.

## How This PR Solves The Issue

- Updates shipped PHPStan config amendment exclude path to include descendants:
  - `__DOCROOT__/sites/*/files/*`
- Updates wrapper fallback exclude paths in `commands/web/phpstan` to the same descendant pattern.
- Adds a behavioral Bats test that creates a nested file under `web/sites/default/files/...` and verifies it is not included in `ddev phpstan --debug` output.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/UltraBob/ddev-drupal-code-quality/tarball/refs/pull/8/head
ddev restart

ddev phpstan analyse --debug -c phpstan.neon web/sites
# Confirm no analyzed paths from web/sites/default/files/**
```

## Automated Testing Overview

Executed:
- `bats ./tests/test.bats --filter "phpstan excludes nested files directory descendants"`
- `bats ./tests/test.bats --filter "phpstan config includes default paths and excludes after install"`
- `bats ./tests/test.bats --filter "install from directory with non-web docroot"`

## Release/Deployment Notes

No deployment steps required beyond shipping a new add-on release. Existing projects can re-run add-on install/update or update `phpstan.neon` excludes manually.