### PR TITLE
Remove restart instruction from installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,6 @@ ddev add-on get UltraBob/ddev-drupal-code-quality
 ddev add-on get /path/to/ddev-drupal-code-quality
 ```
 
-This add-on does not require `ddev restart` by itself. If DDEV asks you to
-restart for separate service/config changes in your project, follow that
-guidance.
-
 ## Repository structure
 
 - `commands/`: DDEV web commands copied into project `.ddev/commands`.


### PR DESCRIPTION
## Summary
Removes the restart instruction from the add-on installation snippet in `README.md`.

## Change
- Deleted `ddev restart` from install steps.
- No replacement restart guidance added.

Closes #9