### PR TITLE
Clarify overlap with related Drupal DDEV add-ons

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ the project type each one is designed for.
 
 ### Practical guidance
 
-- Use one primary Drupal workflow add-on per project.
-- Installing multiple add-ons that define similar commands/configs can cause
-  collisions and confusing behavior.
+- Use the add-on that matches your project type (full-site, contrib, or core).
+- These add-ons overlap in commands/configs and are generally not intended to
+  be combined in one project.
 - If you are developing contrib modules/themes, prefer
   `ddev/ddev-drupal-contrib`.
 - If you are developing Drupal core, prefer `ddev-drupal-core-dev` (see above


### PR DESCRIPTION
## Summary
Adds README guidance on how this add-on relates to other Drupal-focused DDEV add-ons.

## Changes
- Added a new **Related add-ons and overlap** section.
- Added a comparison table for:
  - `UltraBob/ddev-drupal-code-quality`
  - `ddev/ddev-drupal-contrib`
  - `justafish/joachim-n ddev-drupal-core-dev`
- Added practical project-type guidance and overlap notes.

## Notes
- Wording was refined to emphasize project type (full-site, contrib, core).

Closes #6