### PR TITLE
fix: use `ddev describe` to check for a project

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,13 @@ Tools covered:
 ## Installation
 
 ```bash
-# Install from GitHub (current)
+# Install from GitHub
 ddev add-on get UltraBob/ddev-drupal-code-quality
-
-# If/when published to the add-on registry:
-# ddev add-on get ddev-drupal-code-quality
+ddev restart
 
 # Or, for local development
 ddev add-on get /path/to/ddev-drupal-code-quality
+ddev restart
 ```
 
 ## Related add-ons and overlap
@@ -44,9 +43,9 @@ the project type each one is designed for.
 
 | Add-on | Best for | Typical project layout |
 | --- | --- | --- |
-| `UltraBob/ddev-drupal-code-quality` | Full Drupal website projects where your site repo already contains Drupal code and custom code. | Existing site/project repo; installs code-quality configs and IDE shims in-place. |
-| `ddev/ddev-drupal-contrib` | Drupal contrib module/theme development where the contrib project is the center of the repo. | Contrib project repo with Drupal scaffolded around it (symlink workflow). |
-| `justafish/ddev-drupal-core-dev` / `joachim-n/ddev-drupal-core-dev` | Drupal core development. | Drupal core checkout or core-dev project template. |
+| [`UltraBob/ddev-drupal-code-quality`](https://github.com/UltraBob/ddev-drupal-code-quality) | Full Drupal website projects where your site repo already contains Drupal code and custom code. | Existing site/project repo; installs code-quality configs and IDE shims in-place. |
+| [`ddev/ddev-drupal-contrib`](https://github.com/ddev/ddev-drupal-contrib) | Drupal contrib module/theme development where the contrib project is the center of the repo. | Contrib project repo with Drupal scaffolded around it (symlink workflow). |
+| [`justafish/ddev-drupal-core-dev`](https://github.com/justafish/ddev-drupal-core-dev) / [`joachim-n/ddev-drupal-core-dev`](https://github.com/joachim-n/ddev-drupal-core-dev) | Drupal core development. | Drupal core checkout or core-dev project template. |
 
 ### Practical guidance
 

--- a/dcq-install.sh
+++ b/dcq-install.sh
@@ -1713,14 +1713,14 @@ if [ "$non_interactive" -eq 1 ] || [ "$recommended_mode" -eq 1 ]; then
   set_default_env "DCQ_INSTALL_GITIGNORE" "add"
 fi
 
-# Fail loudly if ddev exec cannot resolve a project. Silent skips later are
+# Fail loudly if ddev describe cannot resolve a project. Silent skips later are
 # usually caused by running in a context where DDEV can't find .ddev/config.yaml.
 ddev_cmd="${DDEV_EXECUTABLE:-ddev}"
 if command_available "$ddev_cmd"; then
-  if ! "$ddev_cmd" exec true >/dev/null 2>&1; then
-    emit 'ERROR: ddev exec could not resolve a project from %s.\n' "${PWD:-.}"
+  if ! "$ddev_cmd" describe >/dev/null 2>&1; then
+    emit 'ERROR: ddev describe could not resolve a project from %s.\n' "${PWD:-.}"
     emit 'Run the installer from the target project (for add-on installs, this should be automatic).\n'
-    emit 'Try: cd %s && ddev exec true\n' "$app_root"
+    emit 'Try: cd %s && ddev describe\n' "$app_root"
     exit 1
   fi
 fi


### PR DESCRIPTION
## The Issue

@rfay asked me to test this add-on, so here's my improvement for:

> Unable to install the add-on, when you don't have a running project, because `ddev exec true` doesn't work in this case:
>
> ```
> $ ddev stop
> $ ddev add-on get UltraBob/ddev-drupal-code-quality
> ...
> Executing post-install actions: 
> Accept recommended settings? (y/N) y
> ERROR: ddev exec could not resolve a project from /home/stas/code/ddev/d11/.ddev.
> Run the installer from the target project (for add-on installs, this should be automatic).
> Try: cd /home/stas/code/ddev/d11 && ddev exec true
> 👎  Install Drupal.org GitLab CI template configs and host shims (bash)
> ```

## How This PR Solves The Issue

- Uses `ddev describe` instead of `ddev exec true`, which does the same thing in this situation.
- Updates the README with links to respective add-ons, and removes "If/when published to the add-on registry", since it's already published.

## Manual Testing Instructions

```bash
ddev stop
ddev add-on get https://github.com/UltraBob/ddev-drupal-code-quality/tarball/refs/pull/22/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
