### PR TITLE
claude/fix-issue-27-Wlo2X

### DIFF
--- a/commands/web/stylelint
+++ b/commands/web/stylelint
@@ -175,6 +175,10 @@ normalize_docroot_arg() {
 }
 
 CONFIG_PATH=""
+# LATE_FLAGS holds flags that must survive any CMD reassignment during
+# config discovery (e.g. --ignore-path, --custom-syntax). They are spliced
+# into every invocation via "${CMD[@]}" "${LATE_FLAGS[@]}" ...
+LATE_FLAGS=()
 CMD=(env "NODE_PATH=$NODE_PATH" node "$TOOLCHAIN_BIN")
 DEFAULT_CONFIG_PATH=""
 if [ "$has_config" = false ]; then
@@ -186,7 +190,7 @@ if [ "$has_config" = false ]; then
   DEFAULT_CONFIG_PATH="$CONFIG_PATH"
 fi
 if [ "$has_ignore_path" = false ] && [ -f "${PROJECT_ROOT}/.stylelintignore" ]; then
-  CMD+=(--ignore-path="${PROJECT_ROOT}/.stylelintignore")
+  LATE_FLAGS+=(--ignore-path="${PROJECT_ROOT}/.stylelintignore")
 fi
 
 uses_scss=false
@@ -317,7 +321,7 @@ if [ "$explicit_paths" = false ]; then
     scss_allowed=true
   fi
   if [ "$uses_scss" = true ] && [ "$scss_allowed" = true ] && find_scss_parser; then
-    CMD+=(--custom-syntax="$CUSTOM_SYNTAX_PATH")
+    LATE_FLAGS+=(--custom-syntax="$CUSTOM_SYNTAX_PATH")
     has_scss_parser=true
   fi
   if [ "$uses_scss" = true ] && [ "$scss_allowed" = false ]; then
@@ -332,7 +336,7 @@ if [ "$explicit_paths" = false ]; then
       echo "No CSS files left to lint after excluding SCSS/Sass (config does not support SCSS)." >&2
       exit 2
     fi
-    "${CMD[@]}" "$@" "${FILTERED_FILES[@]}"
+    "${CMD[@]}" "${LATE_FLAGS[@]}" "$@" "${FILTERED_FILES[@]}"
     exit $?
   fi
   if [ "$uses_scss" = true ] && [ "$has_scss_parser" = false ]; then
@@ -347,10 +351,10 @@ if [ "$explicit_paths" = false ]; then
       echo "No CSS files left to lint after excluding SCSS/Sass (no SCSS parser available)." >&2
       exit 2
     fi
-    "${CMD[@]}" "$@" "${FILTERED_FILES[@]}"
+    "${CMD[@]}" "${LATE_FLAGS[@]}" "$@" "${FILTERED_FILES[@]}"
     exit $?
   fi
-  "${CMD[@]}" "$@" "${DEFAULT_FILES[@]}"
+  "${CMD[@]}" "${LATE_FLAGS[@]}" "$@" "${DEFAULT_FILES[@]}"
   exit $?
 fi
 
@@ -363,7 +367,7 @@ if [ "$uses_scss" = true ] && config_supports_scss "$CONFIG_PATH"; then
   scss_allowed=true
 fi
 if [ "$uses_scss" = true ] && [ "$scss_allowed" = true ] && find_scss_parser; then
-  CMD+=(--custom-syntax="$CUSTOM_SYNTAX_PATH")
+  LATE_FLAGS+=(--custom-syntax="$CUSTOM_SYNTAX_PATH")
   has_scss_parser=true
 fi
 
@@ -379,7 +383,7 @@ if [ "$uses_scss" = true ] && [ "$scss_allowed" = false ]; then
     echo "No CSS files left to lint after excluding SCSS/Sass (config does not support SCSS)." >&2
     exit 2
   fi
-  "${CMD[@]}" "${FILTERED_ARGS[@]}"
+  "${CMD[@]}" "${LATE_FLAGS[@]}" "${FILTERED_ARGS[@]}"
   exit $?
 fi
 
@@ -395,9 +399,9 @@ if [ "$uses_scss" = true ] && [ "$has_scss_parser" = false ]; then
     echo "No CSS files left to lint after excluding SCSS/Sass (no SCSS parser available)." >&2
     exit 2
   fi
-  "${CMD[@]}" "${FILTERED_ARGS[@]}"
+  "${CMD[@]}" "${LATE_FLAGS[@]}" "${FILTERED_ARGS[@]}"
   exit $?
 fi
 
-"${CMD[@]}" "${FINAL_ARGS[@]}"
+"${CMD[@]}" "${LATE_FLAGS[@]}" "${FINAL_ARGS[@]}"
 exit $?

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1195,6 +1195,103 @@ JS
   assert_output --partial "/var/www/html/web/themes/custom/dcq_theme/.stylelintrc.json"
 }
 
+@test "stylelint preserves --ignore-path with explicit paths when nearest config triggers CMD reassignment" {
+  set -u -o pipefail
+  export DCQ_INSTALL_DEPS=skip
+  export DCQ_INSTALL_NODE_DEPS=skip
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  # Root config triggers the first CMD reassignment.
+  cat > .stylelintrc.json <<'JSON'
+{
+  "rules": {}
+}
+JSON
+
+  # .stylelintignore is what we expect to survive the reassignments.
+  cat > .stylelintignore <<'TXT'
+web/core/**
+TXT
+
+  # Nearest config inside the theme triggers the explicit-paths CMD reassignment
+  # that previously wiped --ignore-path.
+  mkdir -p web/themes/custom/dcq_theme/css
+  cat > web/themes/custom/dcq_theme/.stylelintrc.json <<'JSON'
+{
+  "rules": {}
+}
+JSON
+  cat > web/themes/custom/dcq_theme/css/fixable.css <<'CSS'
+a {
+  color: RED;
+}
+CSS
+
+  mkdir -p node_modules/stylelint/bin
+  cat > node_modules/stylelint/bin/stylelint.mjs <<'JS'
+#!/usr/bin/env node
+process.stdout.write(process.argv.slice(2).join("\n"));
+JS
+  chmod +x node_modules/stylelint/bin/stylelint.mjs
+
+  run wait_for_container_path "/var/www/html/node_modules/stylelint/bin/stylelint.mjs"
+  assert_success
+
+  run ddev stylelint web/themes/custom/dcq_theme/css/fixable.css
+  assert_success
+  assert_output --partial "--ignore-path="
+  assert_output --partial "/var/www/html/.stylelintignore"
+}
+
+@test "stylelint preserves --ignore-path in default-files mode when nearest config triggers CMD reassignment" {
+  set -u -o pipefail
+  export DCQ_INSTALL_DEPS=skip
+  export DCQ_INSTALL_NODE_DEPS=skip
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  cat > .stylelintrc.json <<'JSON'
+{
+  "rules": {}
+}
+JSON
+
+  cat > .stylelintignore <<'TXT'
+web/core/**
+TXT
+
+  # Nearest config inside the theme triggers the default-files-branch CMD
+  # reassignment that previously wiped --ignore-path.
+  mkdir -p web/themes/custom/dcq_theme/css
+  cat > web/themes/custom/dcq_theme/.stylelintrc.json <<'JSON'
+{
+  "rules": {}
+}
+JSON
+  cat > web/themes/custom/dcq_theme/css/fixable.css <<'CSS'
+a {
+  color: RED;
+}
+CSS
+
+  mkdir -p node_modules/stylelint/bin
+  cat > node_modules/stylelint/bin/stylelint.mjs <<'JS'
+#!/usr/bin/env node
+process.stdout.write(process.argv.slice(2).join("\n"));
+JS
+  chmod +x node_modules/stylelint/bin/stylelint.mjs
+
+  run wait_for_container_path "/var/www/html/node_modules/stylelint/bin/stylelint.mjs"
+  assert_success
+
+  # No explicit paths -- exercises the default-files branch.
+  run ddev stylelint
+  assert_success
+  assert_output --partial "--ignore-path="
+  assert_output --partial "/var/www/html/.stylelintignore"
+}
+
 @test "prettier-fix fails with helpful message when project config is missing" {
   set -u -o pipefail
   export DCQ_INSTALL_DEPS=skip


### PR DESCRIPTION
The stylelint shim appended --ignore-path=.stylelintignore to CMD early,
but later reassigned CMD from scratch when a nearest .stylelintrc.json was
discovered walking upward, silently dropping the ignore flag. In most real
Drupal projects this meant .stylelintignore was ignored and stylelint
scanned core/contrib/vendor.

Introduce a LATE_FLAGS array for flags that must survive config-discovery
reassignments (--ignore-path and --custom-syntax), and splice it into every
invocation. Add bats coverage for both the explicit-paths and default-files
branches to lock in that --ignore-path reaches the stylelint binary even
when a nearer config triggers the CMD reassignment.

stylelint-fix is unaffected -- it already keeps ignore args in a separate
array.