### PR TITLE
Node tooling at project root, installer UX improvements, scan scope fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,9 @@ The template points PHP tooling at `.ddev/drupal-code-quality/tooling/bin` and J
   - `dcq-reports/` is created at the project root when running `checks`
     or the `*-fix` commands (logs + patch previews).
   - Add `dcq-reports/` to `.gitignore` if you do not want to track it.
-- ESLint toolchain selection:
-  - `ESLINT_TOOLCHAIN=auto` (default) prefers root toolchain when root configs exist.
-  - `ESLINT_TOOLCHAIN=core` forces Drupal core JS toolchain.
-  - `ESLINT_TOOLCHAIN=root` forces project root toolchain.
+- ESLint toolchain: Node tooling is installed at the project root only
+  (see `docs/decisions/node-deps-root-only-2026-01-22.md`). All wrappers resolve
+  tools from `node_modules/` at the project root.
 - ESLint config mode:
   - `ESLINT_CONFIG_MODE=nearest` (default) groups by nearest config file.
   - `ESLINT_CONFIG_MODE=fixed` prefers `.eslintrc.passing.json`, then

--- a/README.md
+++ b/README.md
@@ -258,6 +258,34 @@ DCQ_FULL_TESTS=1 bats --jobs 4 ./tests/test.bats
 A weekly GitHub Actions workflow (`upstream-config-check.yml`) automatically
 checks for upstream drift and opens an issue when changes are detected.
 
+## Troubleshooting
+
+### Stylelint crashes with "RangeError: Invalid string length"
+
+On projects with a very large number of Stylelint violations (2000+), the
+default `string` formatter may crash because it builds a single table string
+that exceeds Node.js memory limits. This is a
+[known stylelint limitation](https://github.com/stylelint/stylelint/issues/4133).
+
+**Workaround:** Use the `compact` formatter, which outputs one line per warning
+and does not hit the string length limit:
+
+```bash
+ddev stylelint --formatter compact
+```
+
+### Stylelint crashes with "findLastIndex is not a function"
+
+This means your DDEV container is running Node.js 16 or earlier.
+`Array.prototype.findLastIndex` requires Node.js 18+. Update your DDEV config:
+
+```yaml
+# .ddev/config.yaml
+nodejs_version: "20"
+```
+
+Then run `ddev restart`.
+
 ## Uninstall
 
 Removing the add-on cleans up the `.ddev` payload (commands, shims, assets,

--- a/commands/helpers/node-toolchain.sh
+++ b/commands/helpers/node-toolchain.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#ddev-generated
+# Root-only Node toolchain resolver shared by every Node wrapper.
+#
+# Policy: the add-on installs Node tooling at the project root only. No other
+# locations are consulted. See docs/decisions/node-deps-root-only-2026-01-22.md.
+#
+# Usage:
+#   source /mnt/ddev_config/commands/helpers/node-toolchain.sh
+#   if ! resolve_node_tool "stylelint/bin/stylelint.mjs"; then
+#     echo "Stylelint is not installed..." >&2
+#     exit 127
+#   fi
+#   # TOOLCHAIN_BIN and NODE_PATH are now set.
+
+resolve_node_tool() {
+  local subpath="$1"
+  if [ -z "$subpath" ]; then
+    return 1
+  fi
+  # Compute at call time so the wrapper's PROJECT_ROOT assignment is respected.
+  local nm_root="${PROJECT_ROOT:-/var/www/html}/node_modules"
+  local candidate="${nm_root}/${subpath}"
+  if [ -e "$candidate" ]; then
+    TOOLCHAIN_BIN="$candidate"
+    NODE_PATH="$nm_root"
+    return 0
+  fi
+  return 1
+}

--- a/commands/web/checks
+++ b/commands/web/checks
@@ -58,7 +58,13 @@ for tool in "${TOOLS[@]}"; do
     continue
   fi
 
-  "$tool_path" >"$log_file" 2>&1
+  # Use compact formatter for stylelint in checks mode to avoid RangeError
+  # crash when the table formatter tries to render thousands of violations.
+  if [ "$tool" = "stylelint" ]; then
+    "$tool_path" --formatter compact >"$log_file" 2>&1
+  else
+    "$tool_path" >"$log_file" 2>&1
+  fi
   exit_code=$?
   if [ "$exit_code" -eq 0 ]; then
     STATUS["$tool"]=PASS

--- a/commands/web/cspell
+++ b/commands/web/cspell
@@ -3,6 +3,7 @@
 set -u
 
 source /mnt/ddev_config/commands/helpers/path-map.sh
+source /mnt/ddev_config/commands/helpers/node-toolchain.sh
 
 print_help() {
   cat <<'USAGE'
@@ -59,37 +60,31 @@ fi
 PROJECT_ROOT="/var/www/html"
 DOCROOT="${DCQ_DOCROOT:-web}"
 DOCROOT_PATH="${PROJECT_ROOT}/${DOCROOT}"
-CORE_CSPELL="${DOCROOT_PATH}/core/node_modules/.bin/cspell"
-ROOT_CSPELL="${PROJECT_ROOT}/node_modules/.bin/cspell"
-CSPELL_BIN=""
+TOOLCHAIN_BIN=""
 
 if ! command -v node >/dev/null 2>&1; then
   echo "Node.js is not available in the DDEV web container." >&2
-  echo "Install the Drupal core JS toolchain (${DOCROOT}/core) to run CSpell." >&2
+  echo "Install Node in the DDEV web container to run CSpell." >&2
   exit 127
 fi
 
-if [ -x "$ROOT_CSPELL" ]; then
-  CSPELL_BIN="$ROOT_CSPELL"
-elif [ -x "$CORE_CSPELL" ]; then
-  CSPELL_BIN="$CORE_CSPELL"
-else
-  echo "CSpell is not installed in ${DOCROOT}/core/node_modules or node_modules." >&2
-  echo "Enable corepack and run 'yarn install' in ${DOCROOT}/core, or install cspell in the project root." >&2
+if ! resolve_node_tool ".bin/cspell"; then
+  echo "CSpell is not installed at the project root (${PROJECT_ROOT}/node_modules)." >&2
+  echo "Re-run the DDEV add-on installer and accept Node dependency installation, or install cspell manually in the project root (npm install / yarn install)." >&2
   exit 127
 fi
 
 if [ "$has_help" = true ]; then
-  "$CSPELL_BIN" --help
+  "$TOOLCHAIN_BIN" --help
   exit $?
 fi
 
 if [ "$has_version" = true ]; then
-  "$CSPELL_BIN" --version
+  "$TOOLCHAIN_BIN" --version
   exit $?
 fi
 
-CMD=("$CSPELL_BIN")
+CMD=("$TOOLCHAIN_BIN")
 if [ "$has_config" = false ]; then
   if [ ! -f "${PROJECT_ROOT}/.cspell.json" ]; then
     echo "CSpell config file is missing. Create .cspell.json in the project root (for example by reinstalling the add-on)." >&2

--- a/commands/web/cspell-suggest
+++ b/commands/web/cspell-suggest
@@ -4,6 +4,7 @@
 set -u
 
 source /mnt/ddev_config/commands/helpers/path-map.sh
+source /mnt/ddev_config/commands/helpers/node-toolchain.sh
 
 print_help() {
   cat <<'USAGE'
@@ -70,13 +71,11 @@ fi
 PROJECT_ROOT="/var/www/html"
 DOCROOT="${DCQ_DOCROOT:-web}"
 DOCROOT_PATH="${PROJECT_ROOT}/${DOCROOT}"
-CORE_CSPELL="${DOCROOT_PATH}/core/node_modules/.bin/cspell"
-ROOT_CSPELL="${PROJECT_ROOT}/node_modules/.bin/cspell"
-CSPELL_BIN=""
+TOOLCHAIN_BIN=""
 
 if ! command -v node >/dev/null 2>&1; then
   echo "Node.js is not available in the DDEV web container." >&2
-  echo "Install the Drupal core JS toolchain (${DOCROOT}/core) to run CSpell." >&2
+  echo "Install Node in the DDEV web container to run CSpell." >&2
   exit 127
 fi
 
@@ -91,28 +90,24 @@ UPDATED_WORDS_FILE="${REPORT_DIR}/_cspell_updated_project_words.txt"
 : > "$UNRECOGNIZED_FILE"
 : > "$UPDATED_WORDS_FILE"
 
-if [ -x "$ROOT_CSPELL" ]; then
-  CSPELL_BIN="$ROOT_CSPELL"
-elif [ -x "$CORE_CSPELL" ]; then
-  CSPELL_BIN="$CORE_CSPELL"
-else
-  echo "CSpell is not installed in ${DOCROOT}/core/node_modules or node_modules." >&2
-  echo "Enable corepack and run 'yarn install' in ${DOCROOT}/core, or install cspell in the project root." >&2
+if ! resolve_node_tool ".bin/cspell"; then
+  echo "CSpell is not installed at the project root (${PROJECT_ROOT}/node_modules)." >&2
+  echo "Re-run the DDEV add-on installer and accept Node dependency installation, or install cspell manually in the project root (npm install / yarn install)." >&2
   exit 127
 fi
 
 if [ "$has_help" = true ]; then
-  "$CSPELL_BIN" --help
+  "$TOOLCHAIN_BIN" --help
   exit $?
 fi
 
 if [ "$has_version" = true ]; then
-  "$CSPELL_BIN" --version
+  "$TOOLCHAIN_BIN" --version
   exit $?
 fi
 
 PROJECT_DICTIONARY="${PROJECT_ROOT}/.cspell-project-words.txt"
-CMD=("$CSPELL_BIN")
+CMD=("$TOOLCHAIN_BIN")
 if [ "$has_config" = false ]; then
   if [ ! -f "${PROJECT_ROOT}/.cspell.json" ]; then
     echo "CSpell config file is missing. Create .cspell.json in the project root (for example by reinstalling the add-on)." >&2

--- a/commands/web/eslint
+++ b/commands/web/eslint
@@ -3,6 +3,7 @@
 set -u
 
 source /mnt/ddev_config/commands/helpers/path-map.sh
+source /mnt/ddev_config/commands/helpers/node-toolchain.sh
 
 print_help() {
   cat <<'USAGE'
@@ -24,12 +25,9 @@ explicit_paths=false
 PROJECT_ROOT="/var/www/html"
 DOCROOT="${DCQ_DOCROOT:-web}"
 DOCROOT_PATH="${PROJECT_ROOT}/${DOCROOT}"
-CORE_ESLINT="${DOCROOT_PATH}/core/node_modules/eslint/bin/eslint.js"
-ROOT_ESLINT="${PROJECT_ROOT}/node_modules/eslint/bin/eslint.js"
 TOOLCHAIN_BIN=""
 NODE_PATH=""
 RESOLVE_PLUGINS_DIR=""
-ESLINT_TOOLCHAIN="${ESLINT_TOOLCHAIN:-auto}"
 ESLINT_CONFIG_MODE="${ESLINT_CONFIG_MODE:-nearest}"
 DCQ_ESLINT_QUIET="${DCQ_ESLINT_QUIET:-1}"
 QUIET_ENABLED=1
@@ -80,33 +78,12 @@ if ! command -v node >/dev/null 2>&1; then
   exit 127
 fi
 
-prefer_root=false
-if [ "$ESLINT_TOOLCHAIN" = "root" ]; then
-  prefer_root=true
-elif [ "$ESLINT_TOOLCHAIN" = "auto" ]; then
-  # If the project ships ESLint configs, prefer the root toolchain.
-  if [ -f "${PROJECT_ROOT}/.eslintrc.json" ] || [ -f "${PROJECT_ROOT}/.eslintrc.passing.json" ] || [ -f "${PROJECT_ROOT}/.eslintrc.jquery.json" ]; then
-    prefer_root=true
-  fi
-fi
-
-if [ "$prefer_root" = true ] && [ -f "$ROOT_ESLINT" ]; then
-  TOOLCHAIN_BIN="$ROOT_ESLINT"
-  NODE_PATH="${PROJECT_ROOT}/node_modules"
-  RESOLVE_PLUGINS_DIR="$NODE_PATH"
-elif [ -f "$CORE_ESLINT" ]; then
-  TOOLCHAIN_BIN="$CORE_ESLINT"
-  NODE_PATH="${DOCROOT_PATH}/core/node_modules"
-  RESOLVE_PLUGINS_DIR="$NODE_PATH"
-elif [ -f "$ROOT_ESLINT" ]; then
-  TOOLCHAIN_BIN="$ROOT_ESLINT"
-  NODE_PATH="${PROJECT_ROOT}/node_modules"
-  RESOLVE_PLUGINS_DIR="$NODE_PATH"
-else
-  echo "ESLint is not installed in ${DOCROOT}/core/node_modules or node_modules." >&2
-  echo "Enable corepack and run 'yarn install' in ${DOCROOT}/core, or install eslint in the project root." >&2
+if ! resolve_node_tool "eslint/bin/eslint.js"; then
+  echo "ESLint is not installed at the project root (${PROJECT_ROOT}/node_modules)." >&2
+  echo "Re-run the DDEV add-on installer and accept Node dependency installation, or install eslint manually in the project root (npm install / yarn install)." >&2
   exit 127
 fi
+RESOLVE_PLUGINS_DIR="$NODE_PATH"
 
 if [ "$has_help" = true ]; then
   node "$TOOLCHAIN_BIN" --help
@@ -174,7 +151,7 @@ resolve_plugins_dir() {
     echo ""
     return
   fi
-  # Prefer plugins colocated with the config, then fall back to project/core.
+  # Prefer plugins colocated with the config, then fall back to project root.
   if [[ "$config_dir" != /* ]]; then
     config_dir="${PROJECT_ROOT}/${config_dir}"
   fi
@@ -184,10 +161,6 @@ resolve_plugins_dir() {
   fi
   if [ -d "${PROJECT_ROOT}/node_modules" ]; then
     echo "${PROJECT_ROOT}"
-    return
-  fi
-  if [ -d "${DOCROOT_PATH}/core/node_modules" ]; then
-    echo "${DOCROOT_PATH}/core"
     return
   fi
   echo ""

--- a/commands/web/eslint-fix
+++ b/commands/web/eslint-fix
@@ -4,6 +4,7 @@
 set -u
 
 source /mnt/ddev_config/commands/helpers/path-map.sh
+source /mnt/ddev_config/commands/helpers/node-toolchain.sh
 
 print_help() {
   cat <<'USAGE'
@@ -32,7 +33,6 @@ seen_double_dash=false
 explicit_paths=false
 preview_mode=false
 clean_args=()
-ESLINT_TOOLCHAIN="${ESLINT_TOOLCHAIN:-auto}"
 ESLINT_CONFIG_MODE="${ESLINT_CONFIG_MODE:-nearest}"
 DCQ_ESLINT_QUIET="${DCQ_ESLINT_QUIET:-1}"
 QUIET_ENABLED=1
@@ -88,38 +88,16 @@ fi
 PROJECT_ROOT="/var/www/html"
 DOCROOT="${DCQ_DOCROOT:-web}"
 DOCROOT_PATH="${PROJECT_ROOT}/${DOCROOT}"
-CORE_ESLINT="${DOCROOT_PATH}/core/node_modules/eslint/bin/eslint.js"
-ROOT_ESLINT="${PROJECT_ROOT}/node_modules/eslint/bin/eslint.js"
 TOOLCHAIN_BIN=""
 NODE_PATH=""
 RESOLVE_PLUGINS_DIR=""
 
-prefer_root=false
-if [ "$ESLINT_TOOLCHAIN" = "root" ]; then
-  prefer_root=true
-elif [ "$ESLINT_TOOLCHAIN" = "auto" ]; then
-  if [ -f "${PROJECT_ROOT}/.eslintrc.json" ] || [ -f "${PROJECT_ROOT}/.eslintrc.passing.json" ] || [ -f "${PROJECT_ROOT}/.eslintrc.jquery.json" ]; then
-    prefer_root=true
-  fi
-fi
-
-if [ "$prefer_root" = true ] && [ -f "$ROOT_ESLINT" ]; then
-  TOOLCHAIN_BIN="$ROOT_ESLINT"
-  NODE_PATH="${PROJECT_ROOT}/node_modules"
-  RESOLVE_PLUGINS_DIR="$NODE_PATH"
-elif [ -f "$CORE_ESLINT" ]; then
-  TOOLCHAIN_BIN="$CORE_ESLINT"
-  NODE_PATH="${DOCROOT_PATH}/core/node_modules"
-  RESOLVE_PLUGINS_DIR="$NODE_PATH"
-elif [ -f "$ROOT_ESLINT" ]; then
-  TOOLCHAIN_BIN="$ROOT_ESLINT"
-  NODE_PATH="${PROJECT_ROOT}/node_modules"
-  RESOLVE_PLUGINS_DIR="$NODE_PATH"
-else
-  echo "ESLint is not installed in ${DOCROOT}/core/node_modules or node_modules." >&2
-  echo "Enable corepack and run 'yarn install' in ${DOCROOT}/core, or install eslint in the project root." >&2
+if ! resolve_node_tool "eslint/bin/eslint.js"; then
+  echo "ESLint is not installed at the project root (${PROJECT_ROOT}/node_modules)." >&2
+  echo "Re-run the DDEV add-on installer and accept Node dependency installation, or install eslint manually in the project root (npm install / yarn install)." >&2
   exit 127
 fi
+RESOLVE_PLUGINS_DIR="$NODE_PATH"
 
 if [ "$has_help" = true ]; then
   node "$TOOLCHAIN_BIN" --help
@@ -257,10 +235,6 @@ resolve_plugins_dir() {
     echo "${PROJECT_ROOT}"
     return
   fi
-  if [ -d "${DOCROOT_PATH}/core/node_modules" ]; then
-    echo "${DOCROOT_PATH}/core"
-    return
-  fi
   echo ""
 }
 
@@ -372,9 +346,9 @@ if [ "$preview_mode" = true ]; then
     --exclude=./.git \
     --exclude=./.trunk \
     --exclude=./node_modules \
+    --exclude="./${DOCROOT}/*/node_modules" \
     --exclude=./vendor \
     --exclude=./dcq-reports \
-    --exclude=./${DOCROOT}/core/node_modules \
     --exclude='*/.git' \
     --exclude='*/.git/*' \
     . | (cd "$tmp_root" && tar -xf -)

--- a/commands/web/prettier
+++ b/commands/web/prettier
@@ -3,6 +3,7 @@
 set -u
 
 source /mnt/ddev_config/commands/helpers/path-map.sh
+source /mnt/ddev_config/commands/helpers/node-toolchain.sh
 
 print_help() {
   cat <<'USAGE'
@@ -59,43 +60,35 @@ fi
 PROJECT_ROOT="/var/www/html"
 DOCROOT="${DCQ_DOCROOT:-web}"
 DOCROOT_PATH="${PROJECT_ROOT}/${DOCROOT}"
-CORE_PRETTIER="${DOCROOT_PATH}/core/node_modules/.bin/prettier"
-ROOT_PRETTIER="${PROJECT_ROOT}/node_modules/.bin/prettier"
-PRETTIER_BIN=""
+TOOLCHAIN_BIN=""
 NODE_PATH=""
 
 if ! command -v node >/dev/null 2>&1; then
   echo "Node.js is not available in the DDEV web container." >&2
-  echo "Install the Drupal core JS toolchain (${DOCROOT}/core) to run Prettier." >&2
+  echo "Install Node in the DDEV web container to run Prettier." >&2
   exit 127
 fi
 
-if [ -x "$ROOT_PRETTIER" ]; then
-  PRETTIER_BIN="$ROOT_PRETTIER"
-  NODE_PATH="${PROJECT_ROOT}/node_modules"
-elif [ -x "$CORE_PRETTIER" ]; then
-  PRETTIER_BIN="$CORE_PRETTIER"
-  NODE_PATH="${DOCROOT_PATH}/core/node_modules"
-else
-  echo "Prettier is not installed in ${DOCROOT}/core/node_modules or node_modules." >&2
-  echo "Enable corepack and run 'yarn install' in ${DOCROOT}/core, or install prettier in the project root." >&2
+if ! resolve_node_tool ".bin/prettier"; then
+  echo "Prettier is not installed at the project root (${PROJECT_ROOT}/node_modules)." >&2
+  echo "Re-run the DDEV add-on installer and accept Node dependency installation, or install prettier manually in the project root (npm install / yarn install)." >&2
   exit 127
 fi
 
 if [ "$has_help" = true ]; then
-  "$PRETTIER_BIN" --help
+  "$TOOLCHAIN_BIN" --help
   exit $?
 fi
 
 if [ "$has_version" = true ]; then
-  "$PRETTIER_BIN" --version
+  "$TOOLCHAIN_BIN" --version
   exit $?
 fi
 
 # Run from the Drupal docroot so config resolution matches CI expectations.
 cd "$DOCROOT"
 
-CMD=(env "NODE_PATH=$NODE_PATH" "$PRETTIER_BIN" --check)
+CMD=(env "NODE_PATH=$NODE_PATH" "$TOOLCHAIN_BIN" --check)
 if [ "$has_config" = false ]; then
   if [ ! -f "${PROJECT_ROOT}/.prettierrc.json" ]; then
     echo "Prettier config file is missing. Create .prettierrc.json in the project root (for example by reinstalling the add-on)." >&2

--- a/commands/web/prettier-fix
+++ b/commands/web/prettier-fix
@@ -4,6 +4,7 @@
 set -u
 
 source /mnt/ddev_config/commands/helpers/path-map.sh
+source /mnt/ddev_config/commands/helpers/node-toolchain.sh
 
 print_help() {
   cat <<'USAGE'
@@ -24,8 +25,6 @@ USAGE
 PROJECT_ROOT="/var/www/html"
 DOCROOT="${DCQ_DOCROOT:-web}"
 DOCROOT_PATH="${PROJECT_ROOT}/${DOCROOT}"
-CORE_PRETTIER="${DOCROOT_PATH}/core/node_modules/prettier/bin/prettier.cjs"
-ROOT_PRETTIER="${PROJECT_ROOT}/node_modules/prettier/bin/prettier.cjs"
 TOOLCHAIN_BIN=""
 NODE_PATH=""
 
@@ -83,19 +82,13 @@ fi
 
 if ! command -v node >/dev/null 2>&1; then
   echo "Node.js is not available in the DDEV web container." >&2
-  echo "Install the Drupal core JS toolchain (${DOCROOT}/core) to run Prettier." >&2
+  echo "Install Node in the DDEV web container to run Prettier." >&2
   exit 127
 fi
 
-if [ -f "$ROOT_PRETTIER" ]; then
-  TOOLCHAIN_BIN="$ROOT_PRETTIER"
-  NODE_PATH="${PROJECT_ROOT}/node_modules"
-elif [ -f "$CORE_PRETTIER" ]; then
-  TOOLCHAIN_BIN="$CORE_PRETTIER"
-  NODE_PATH="${DOCROOT_PATH}/core/node_modules"
-else
-  echo "Prettier is not installed in ${DOCROOT}/core/node_modules or node_modules." >&2
-  echo "Enable corepack and run 'yarn install' in ${DOCROOT}/core, or install prettier in the project root." >&2
+if ! resolve_node_tool "prettier/bin/prettier.cjs"; then
+  echo "Prettier is not installed at the project root (${PROJECT_ROOT}/node_modules)." >&2
+  echo "Re-run the DDEV add-on installer and accept Node dependency installation, or install prettier manually in the project root (npm install / yarn install)." >&2
   exit 127
 fi
 
@@ -276,9 +269,9 @@ if [ "$preview_mode" = true ]; then
     --exclude=./.git \
     --exclude=./.trunk \
     --exclude=./node_modules \
+    --exclude="./${DOCROOT}/*/node_modules" \
     --exclude=./vendor \
     --exclude=./dcq-reports \
-    --exclude=./${DOCROOT}/core/node_modules \
     --exclude='*/.git' \
     --exclude='*/.git/*' \
     . | (cd "$tmp_root" && tar -xf -)

--- a/commands/web/stylelint
+++ b/commands/web/stylelint
@@ -80,9 +80,11 @@ USAGE
 done
 
 # Inject default globs when no file paths are supplied, so bare
-# `ddev stylelint` scans all style files via .stylelintignore exclusions.
+# `ddev stylelint` scans style files via .stylelintignore exclusions.
+# Override with DCQ_STYLELINT_GLOBS (space-separated, stylelint CLI syntax).
 if [ "$has_positional" = false ]; then
-  args+=('**/*.css' '**/*.scss' '**/*.sass')
+  read -ra _globs <<< "${DCQ_STYLELINT_GLOBS:-**/*.css}"
+  args+=("${_globs[@]}")
 fi
 
 # Run from project root so native .stylelintignore auto-discovery and

--- a/commands/web/stylelint
+++ b/commands/web/stylelint
@@ -80,13 +80,22 @@ USAGE
 done
 
 # Inject default globs when no file paths are supplied, so bare
-# `ddev stylelint` scans all custom code via .stylelintignore exclusions.
+# `ddev stylelint` scans all CSS via .stylelintignore exclusions.
 if [ "$has_positional" = false ]; then
-  args+=('**/*.css' '**/*.scss' '**/*.sass')
+  args+=('**/*.css')
 fi
 
 # Run from project root so native .stylelintignore auto-discovery and
 # cosmiconfig upward config walk work correctly.
 cd "$PROJECT_ROOT"
+
+# Hint about SCSS/Sass if present but not in default scan scope.
+if [ "$has_positional" = false ]; then
+  if find . -name '*.scss' -o -name '*.sass' 2>/dev/null | grep -q .; then
+    echo "Tip: SCSS/Sass files found but not included in the default scan." >&2
+    echo "To lint SCSS, extend stylelint-config-standard-scss in your .stylelintrc.json" >&2
+    echo "and pass SCSS paths explicitly, e.g.: ddev stylelint '**/*.scss'" >&2
+  fi
+fi
 
 exec env NODE_PATH="$NODE_PATH" node "$TOOLCHAIN_BIN" "${args[@]}"

--- a/commands/web/stylelint
+++ b/commands/web/stylelint
@@ -39,6 +39,7 @@ args=()
 has_positional=false
 after_double_dash=false
 map_next=false
+pass_next=false
 
 for arg in "$@"; do
   if [ "$after_double_dash" = true ]; then
@@ -49,6 +50,11 @@ for arg in "$@"; do
   if [ "$map_next" = true ]; then
     args+=("$(map_path "$arg")")
     map_next=false
+    continue
+  fi
+  if [ "$pass_next" = true ]; then
+    args+=("$arg")
+    pass_next=false
     continue
   fi
   case "$arg" in
@@ -71,6 +77,10 @@ USAGE
     -c|--config|--ignore-path)
       args+=("$arg")
       map_next=true
+      ;;
+    -f|--formatter|--custom-formatter|--custom-syntax|-o|--output-file|--cache-location|--max-warnings|--stdin-filename|--suppress-location)
+      args+=("$arg")
+      pass_next=true
       ;;
     --config=*|--ignore-path=*)
       flag="${arg%%=*}"

--- a/commands/web/stylelint
+++ b/commands/web/stylelint
@@ -92,9 +92,9 @@ cd "$PROJECT_ROOT"
 # Hint about SCSS/Sass if present but not in default scan scope.
 if [ "$has_positional" = false ]; then
   if find . \( -path ./node_modules -o -path ./vendor \) -prune -o \( -name '*.scss' -o -name '*.sass' \) -print -quit 2>/dev/null | grep -q .; then
-    echo "Tip: SCSS/Sass files found but not included in the default scan." >&2
-    echo "To lint SCSS, extend stylelint-config-standard-scss in your .stylelintrc.json" >&2
-    echo "and pass SCSS paths explicitly, e.g.: ddev stylelint '**/*.scss'" >&2
+    echo "Tip: SCSS/Sass files detected but not included in the default scan." >&2
+    echo "To add SCSS to default runs: extend stylelint-config-standard-scss in" >&2
+    echo "your .stylelintrc.json, then run: ddev stylelint '**/*.css' '**/*.scss'" >&2
   fi
 fi
 

--- a/commands/web/stylelint
+++ b/commands/web/stylelint
@@ -80,22 +80,13 @@ USAGE
 done
 
 # Inject default globs when no file paths are supplied, so bare
-# `ddev stylelint` scans all CSS via .stylelintignore exclusions.
+# `ddev stylelint` scans all style files via .stylelintignore exclusions.
 if [ "$has_positional" = false ]; then
-  args+=('**/*.css')
+  args+=('**/*.css' '**/*.scss' '**/*.sass')
 fi
 
 # Run from project root so native .stylelintignore auto-discovery and
 # cosmiconfig upward config walk work correctly.
 cd "$PROJECT_ROOT"
-
-# Hint about SCSS/Sass if present but not in default scan scope.
-if [ "$has_positional" = false ]; then
-  if find . \( -path ./node_modules -o -path ./vendor \) -prune -o \( -name '*.scss' -o -name '*.sass' \) -print -quit 2>/dev/null | grep -q .; then
-    echo "Tip: SCSS/Sass files detected but not included in the default scan." >&2
-    echo "To add SCSS to default runs: extend stylelint-config-standard-scss in" >&2
-    echo "your .stylelintrc.json, then run: ddev stylelint '**/*.css' '**/*.scss'" >&2
-  fi
-fi
 
 exec env NODE_PATH="$NODE_PATH" node "$TOOLCHAIN_BIN" "${args[@]}"

--- a/commands/web/stylelint
+++ b/commands/web/stylelint
@@ -16,6 +16,14 @@ if ! command -v node >/dev/null 2>&1; then
   exit 127
 fi
 
+# Stylelint requires Node.js 18+ (Array.prototype.findLastIndex).
+NODE_MAJOR="$(node -e 'console.log(process.versions.node.split(".")[0])')"
+if [ "${NODE_MAJOR:-0}" -lt 18 ]; then
+  echo "Error: Node.js $NODE_MAJOR is too old. Stylelint requires Node.js 18 or later." >&2
+  echo "Update nodejs_version in .ddev/config.yaml (recommended: \"20\") and run \"ddev restart\"." >&2
+  exit 1
+fi
+
 if ! resolve_node_tool "stylelint/bin/stylelint.mjs"; then
   echo "Stylelint is not installed at the project root (${PROJECT_ROOT}/node_modules)." >&2
   echo "Re-run the DDEV add-on installer and accept Node dependency installation," >&2

--- a/commands/web/stylelint
+++ b/commands/web/stylelint
@@ -5,396 +5,88 @@ set -u
 source /mnt/ddev_config/commands/helpers/path-map.sh
 source /mnt/ddev_config/commands/helpers/node-toolchain.sh
 
-print_help() {
-  cat <<'USAGE'
-Usage: ddev stylelint [args]
-
-Runs Stylelint inside the DDEV web container with Drupal.org GitLab CI template defaults.
-USAGE
-}
-
 PROJECT_ROOT="/var/www/html"
-DOCROOT="${DCQ_DOCROOT:-web}"
-DOCROOT_PATH="${PROJECT_ROOT}/${DOCROOT}"
 TOOLCHAIN_BIN=""
 NODE_PATH=""
 
-has_help=false
-has_version=false
-has_positional=false
-has_config=false
-has_ignore_path=false
-seen_double_dash=false
-explicit_paths=false
-
-for arg in "$@"; do
-  if [ "$seen_double_dash" = true ]; then
-    has_positional=true
-    explicit_paths=true
-    break
-  fi
-  case "$arg" in
-    --)
-      seen_double_dash=true
-      ;;
-    -h|--help)
-      has_help=true
-      ;;
-    -V|--version)
-      has_version=true
-      ;;
-    -c|--config|--config=*)
-      has_config=true
-      ;;
-    --ignore-path|--ignore-path=*)
-      has_ignore_path=true
-      ;;
-    --)
-      ;;
-    -* )
-      ;;
-    *)
-      has_positional=true
-      explicit_paths=true
-      ;;
-  esac
-  if [ "$has_help" = true ] || [ "$has_version" = true ]; then
-    break
-  fi
-done
-
-if [ "$has_help" = true ]; then
-  print_help
-fi
+# --- Toolchain resolution (root only) ---
 
 if ! command -v node >/dev/null 2>&1; then
   echo "Node.js is not available in the DDEV web container." >&2
-  echo "Install the Drupal core JS toolchain (${DOCROOT}/core) to run Stylelint." >&2
   exit 127
 fi
 
 if ! resolve_node_tool "stylelint/bin/stylelint.mjs"; then
   echo "Stylelint is not installed at the project root (${PROJECT_ROOT}/node_modules)." >&2
-  echo "Re-run the DDEV add-on installer and accept Node dependency installation, or install stylelint manually in the project root (npm install / yarn install)." >&2
+  echo "Re-run the DDEV add-on installer and accept Node dependency installation," >&2
+  echo "or install stylelint manually (npm install / yarn install)." >&2
   exit 127
 fi
 
-PROJECT_ROOT="/var/www/html"
+# --- Argument translation ---
+# Map host-absolute paths (from IDE invocations) to container paths.
+# Detect whether file paths were supplied (for default-glob injection).
 
-if [ "$has_help" = true ]; then
-  node "$TOOLCHAIN_BIN" --help
-  exit $?
+args=()
+has_positional=false
+after_double_dash=false
+map_next=false
+
+for arg in "$@"; do
+  if [ "$after_double_dash" = true ]; then
+    args+=("$(map_path "$arg")")
+    has_positional=true
+    continue
+  fi
+  if [ "$map_next" = true ]; then
+    args+=("$(map_path "$arg")")
+    map_next=false
+    continue
+  fi
+  case "$arg" in
+    -h|--help)
+      cat <<'USAGE'
+Usage: ddev stylelint [args]
+
+Runs Stylelint inside the DDEV web container with Drupal.org GitLab CI
+template defaults. All flags are passed through to stylelint.
+USAGE
+      exec env NODE_PATH="$NODE_PATH" node "$TOOLCHAIN_BIN" --help
+      ;;
+    -V|--version)
+      exec env NODE_PATH="$NODE_PATH" node "$TOOLCHAIN_BIN" --version
+      ;;
+    --)
+      args+=("$arg")
+      after_double_dash=true
+      ;;
+    -c|--config|--ignore-path)
+      args+=("$arg")
+      map_next=true
+      ;;
+    --config=*|--ignore-path=*)
+      flag="${arg%%=*}"
+      value="${arg#*=}"
+      args+=("${flag}=$(map_path "$value")")
+      ;;
+    -*)
+      args+=("$arg")
+      ;;
+    *)
+      args+=("$(map_path "$arg")")
+      has_positional=true
+      ;;
+  esac
+done
+
+# Inject default globs when no file paths are supplied, so bare
+# `ddev stylelint` scans all custom code via .stylelintignore exclusions.
+if [ "$has_positional" = false ]; then
+  args+=('**/*.css' '**/*.scss' '**/*.sass')
 fi
 
-if [ "$has_version" = true ]; then
-  node "$TOOLCHAIN_BIN" --version
-  exit $?
-fi
+# Run from project root so native .stylelintignore auto-discovery and
+# cosmiconfig upward config walk work correctly.
+cd "$PROJECT_ROOT"
 
-# Run from the Drupal docroot so default configs resolve as expected.
-cd "$DOCROOT"
-
-find_stylelint_config() {
-  local path="$1"
-  local dir="$path"
-  if [ -f "$dir" ]; then
-    dir="$(dirname "$dir")"
-  fi
-  while [ "$dir" != "." ] && [ "$dir" != "/" ]; do
-    # Walk upward to find the closest Stylelint config.
-    for candidate in .stylelintrc .stylelintrc.json .stylelintrc.yaml .stylelintrc.yml .stylelintrc.js; do
-      if [ -f "$dir/$candidate" ]; then
-        echo "$dir/$candidate"
-        return 0
-      fi
-    done
-    dir="$(dirname "$dir")"
-  done
-  return 1
-}
-
-CUSTOM_SYNTAX_PATH=""
-find_scss_parser() {
-  local path
-  IFS=':' read -r -a paths <<< "$NODE_PATH"
-  for path in "${paths[@]}"; do
-    [ -z "$path" ] && continue
-    if [[ "$path" != /* ]]; then
-      path="${DOCROOT_PATH}/${path}"
-    fi
-    # Look for postcss-scss so SCSS/Sass files can be parsed safely.
-    if [ -f "$path/postcss-scss/lib/scss-syntax.js" ]; then
-      CUSTOM_SYNTAX_PATH="$path/postcss-scss/lib/scss-syntax.js"
-      return 0
-    fi
-  done
-  return 1
-}
-
-config_supports_scss() {
-  local path="$1"
-  local full_path="$path"
-  if [ -z "$full_path" ]; then
-    return 1
-  fi
-  if [[ "$full_path" != /* ]]; then
-    full_path="${DOCROOT_PATH}/${full_path}"
-  fi
-  if [ ! -f "$full_path" ]; then
-    return 1
-  fi
-  # Detect SCSS support by searching for known presets/plugins.
-  if grep -E -q 'stylelint-scss|standard-scss|recommended-scss' "$full_path"; then
-    return 0
-  fi
-  return 1
-}
-
-normalize_docroot_arg() {
-  local arg="$1"
-  arg="$(map_path "$arg")"
-  if [[ "$arg" == /var/www/html/* ]]; then
-    arg="${arg#/var/www/html/}"
-  fi
-  if [ "$DOCROOT" != "web" ] && [[ "$arg" == web/* ]]; then
-    arg="${DOCROOT}/${arg#web/}"
-  fi
-  if [[ "$arg" == "${DOCROOT}/"* ]]; then
-    arg="${arg#${DOCROOT}/}"
-  elif [ "$arg" = "$DOCROOT" ]; then
-    arg="."
-  fi
-  printf '%s' "$arg"
-}
-
-CONFIG_PATH=""
-# LATE_FLAGS holds flags that must survive any CMD reassignment during
-# config discovery (e.g. --ignore-path, --custom-syntax). They are spliced
-# into every invocation via "${CMD[@]}" "${LATE_FLAGS[@]}" ...
-LATE_FLAGS=()
-CMD=(env "NODE_PATH=$NODE_PATH" node "$TOOLCHAIN_BIN")
-DEFAULT_CONFIG_PATH=""
-if [ "$has_config" = false ]; then
-  if [ -f "${PROJECT_ROOT}/.stylelintrc.json" ]; then
-    CONFIG_PATH="${PROJECT_ROOT}/.stylelintrc.json"
-    config_dir="$(dirname "$CONFIG_PATH")"
-    CMD=(env "NODE_PATH=$NODE_PATH" node "$TOOLCHAIN_BIN" --config="$CONFIG_PATH" --config-basedir="$config_dir")
-  fi
-  DEFAULT_CONFIG_PATH="$CONFIG_PATH"
-fi
-if [ "$has_ignore_path" = false ] && [ -f "${PROJECT_ROOT}/.stylelintignore" ]; then
-  LATE_FLAGS+=(--ignore-path="${PROJECT_ROOT}/.stylelintignore")
-fi
-
-uses_scss=false
-has_scss_parser=false
-scss_allowed=false
-
-FINAL_ARGS=()
-if [ "$explicit_paths" = true ]; then
-  args=("$@")
-  arg_count=${#args[@]}
-  index=0
-  seen_double_dash=false
-  while [ "$index" -lt "$arg_count" ]; do
-    arg="${args[$index]}"
-    if [ "$seen_double_dash" = true ]; then
-      arg="$(normalize_docroot_arg "$arg")"
-      FINAL_ARGS+=("$arg")
-      index=$((index + 1))
-      continue
-    fi
-    case "$arg" in
-      --)
-        seen_double_dash=true
-        FINAL_ARGS+=("$arg")
-        ;;
-      -c|--config)
-        next_arg="${args[$((index + 1))]:-}"
-        next_arg="$(normalize_docroot_arg "$next_arg")"
-        FINAL_ARGS+=("$arg" "$next_arg")
-        index=$((index + 1))
-        ;;
-      --ignore-path)
-        next_arg="${args[$((index + 1))]:-}"
-        FINAL_ARGS+=("$arg" "$(map_path "$next_arg")")
-        index=$((index + 1))
-        ;;
-      --config=*)
-        config_value="${arg#*=}"
-        config_value="$(normalize_docroot_arg "$config_value")"
-        FINAL_ARGS+=("--config=$config_value")
-        ;;
-      --ignore-path=*)
-        ignore_value="${arg#*=}"
-        FINAL_ARGS+=("--ignore-path=$(map_path "$ignore_value")")
-        ;;
-      -* )
-        FINAL_ARGS+=("$arg")
-        ;;
-      *)
-        arg="$(normalize_docroot_arg "$arg")"
-        FINAL_ARGS+=("$arg")
-        ;;
-    esac
-    index=$((index + 1))
-  done
-
-  if [ "$has_config" = false ] && [ "$CONFIG_PATH" = "$DEFAULT_CONFIG_PATH" ]; then
-    for path in "${FINAL_ARGS[@]}"; do
-      if config_candidate="$(find_stylelint_config "$path")"; then
-        CONFIG_PATH="$config_candidate"
-        config_dir="$(dirname "$CONFIG_PATH")"
-        if [[ "$config_dir" != /* ]]; then
-          config_dir="${DOCROOT_PATH}/${config_dir}"
-        fi
-        if [ -d "$config_dir/node_modules" ]; then
-          NODE_PATH="${NODE_PATH}:${config_dir}/node_modules"
-        fi
-        CMD=(env "NODE_PATH=$NODE_PATH" node "$TOOLCHAIN_BIN" --config="$CONFIG_PATH" --config-basedir="$config_dir")
-        break
-      fi
-    done
-  fi
-
-  for path in "${FINAL_ARGS[@]}"; do
-    if [[ "$path" == *.scss || "$path" == *.sass ]]; then
-      uses_scss=true
-      break
-    fi
-    if [ -d "$path" ]; then
-      if find "$path" -type f \( -name '*.scss' -o -name '*.sass' \) -print -quit 2>/dev/null | grep -q .; then
-        uses_scss=true
-        break
-      fi
-    fi
-  done
-fi
-
-if [ "$explicit_paths" = false ]; then
-  DEFAULT_FILES=()
-  for candidate in .; do
-    if [ -d "$candidate" ]; then
-      while IFS= read -r file_path; do
-        DEFAULT_FILES+=("$file_path")
-      done < <(find "$candidate" -path '*/node_modules/*' -prune -o -type f \( -name '*.css' -o -name '*.scss' -o -name '*.sass' \) -print)
-    fi
-  done
-  if [ "${#DEFAULT_FILES[@]}" -eq 0 ]; then
-    echo "No style files found under ${DOCROOT}. Nothing to lint." >&2
-    exit 2
-  fi
-  if [ "$has_config" = false ] && [ "$CONFIG_PATH" = "$DEFAULT_CONFIG_PATH" ]; then
-    for file_path in "${DEFAULT_FILES[@]}"; do
-      if config_candidate="$(find_stylelint_config "$file_path")"; then
-        CONFIG_PATH="$config_candidate"
-        config_dir="$(dirname "$CONFIG_PATH")"
-        if [[ "$config_dir" != /* ]]; then
-          config_dir="${DOCROOT_PATH}/${config_dir}"
-        fi
-        if [ -d "$config_dir/node_modules" ]; then
-          NODE_PATH="${NODE_PATH}:${config_dir}/node_modules"
-        fi
-        CMD=(env "NODE_PATH=$NODE_PATH" node "$TOOLCHAIN_BIN" --config="$CONFIG_PATH" --config-basedir="$config_dir")
-        break
-      fi
-    done
-  fi
-  if [ "$has_config" = false ] && [ -z "$CONFIG_PATH" ]; then
-    echo "Stylelint config file is missing. Create .stylelintrc.json in the project root (or a nearest config in the target paths), or pass --config." >&2
-    exit 2
-  fi
-  for file_path in "${DEFAULT_FILES[@]}"; do
-    if [[ "$file_path" == *.scss || "$file_path" == *.sass ]]; then
-      uses_scss=true
-      break
-    fi
-  done
-  if [ "$uses_scss" = true ] && config_supports_scss "$CONFIG_PATH"; then
-    scss_allowed=true
-  fi
-  if [ "$uses_scss" = true ] && [ "$scss_allowed" = true ] && find_scss_parser; then
-    LATE_FLAGS+=(--custom-syntax="$CUSTOM_SYNTAX_PATH")
-    has_scss_parser=true
-  fi
-  if [ "$uses_scss" = true ] && [ "$scss_allowed" = false ]; then
-    FILTERED_FILES=()
-    for file_path in "${DEFAULT_FILES[@]}"; do
-      if [[ "$file_path" == *.scss || "$file_path" == *.sass ]]; then
-        continue
-      fi
-      FILTERED_FILES+=("$file_path")
-    done
-    if [ "${#FILTERED_FILES[@]}" -eq 0 ]; then
-      echo "No CSS files left to lint after excluding SCSS/Sass (config does not support SCSS)." >&2
-      exit 2
-    fi
-    "${CMD[@]}" "${LATE_FLAGS[@]}" "$@" "${FILTERED_FILES[@]}"
-    exit $?
-  fi
-  if [ "$uses_scss" = true ] && [ "$has_scss_parser" = false ]; then
-    FILTERED_FILES=()
-    for file_path in "${DEFAULT_FILES[@]}"; do
-      if [[ "$file_path" == *.scss || "$file_path" == *.sass ]]; then
-        continue
-      fi
-      FILTERED_FILES+=("$file_path")
-    done
-    if [ "${#FILTERED_FILES[@]}" -eq 0 ]; then
-      echo "No CSS files left to lint after excluding SCSS/Sass (no SCSS parser available)." >&2
-      exit 2
-    fi
-    "${CMD[@]}" "${LATE_FLAGS[@]}" "$@" "${FILTERED_FILES[@]}"
-    exit $?
-  fi
-  "${CMD[@]}" "${LATE_FLAGS[@]}" "$@" "${DEFAULT_FILES[@]}"
-  exit $?
-fi
-
-if [ "$has_config" = false ] && [ -z "$CONFIG_PATH" ]; then
-  echo "Stylelint config file is missing. Create .stylelintrc.json in the project root (or a nearest config in the target paths), or pass --config." >&2
-  exit 2
-fi
-
-if [ "$uses_scss" = true ] && config_supports_scss "$CONFIG_PATH"; then
-  scss_allowed=true
-fi
-if [ "$uses_scss" = true ] && [ "$scss_allowed" = true ] && find_scss_parser; then
-  LATE_FLAGS+=(--custom-syntax="$CUSTOM_SYNTAX_PATH")
-  has_scss_parser=true
-fi
-
-if [ "$uses_scss" = true ] && [ "$scss_allowed" = false ]; then
-  FILTERED_ARGS=()
-  for arg in "${FINAL_ARGS[@]}"; do
-    if [[ "$arg" == *.scss || "$arg" == *.sass ]]; then
-      continue
-    fi
-    FILTERED_ARGS+=("$arg")
-  done
-  if [ "${#FILTERED_ARGS[@]}" -eq 0 ]; then
-    echo "No CSS files left to lint after excluding SCSS/Sass (config does not support SCSS)." >&2
-    exit 2
-  fi
-  "${CMD[@]}" "${LATE_FLAGS[@]}" "${FILTERED_ARGS[@]}"
-  exit $?
-fi
-
-if [ "$uses_scss" = true ] && [ "$has_scss_parser" = false ]; then
-  FILTERED_ARGS=()
-  for arg in "${FINAL_ARGS[@]}"; do
-    if [[ "$arg" == *.scss || "$arg" == *.sass ]]; then
-      continue
-    fi
-    FILTERED_ARGS+=("$arg")
-  done
-  if [ "${#FILTERED_ARGS[@]}" -eq 0 ]; then
-    echo "No CSS files left to lint after excluding SCSS/Sass (no SCSS parser available)." >&2
-    exit 2
-  fi
-  "${CMD[@]}" "${LATE_FLAGS[@]}" "${FILTERED_ARGS[@]}"
-  exit $?
-fi
-
-"${CMD[@]}" "${LATE_FLAGS[@]}" "${FINAL_ARGS[@]}"
-exit $?
+exec env NODE_PATH="$NODE_PATH" node "$TOOLCHAIN_BIN" "${args[@]}"

--- a/commands/web/stylelint
+++ b/commands/web/stylelint
@@ -3,6 +3,7 @@
 set -u
 
 source /mnt/ddev_config/commands/helpers/path-map.sh
+source /mnt/ddev_config/commands/helpers/node-toolchain.sh
 
 print_help() {
   cat <<'USAGE'
@@ -15,8 +16,6 @@ USAGE
 PROJECT_ROOT="/var/www/html"
 DOCROOT="${DCQ_DOCROOT:-web}"
 DOCROOT_PATH="${PROJECT_ROOT}/${DOCROOT}"
-CORE_STYLELINT="${DOCROOT_PATH}/core/node_modules/stylelint/bin/stylelint.mjs"
-ROOT_STYLELINT="${PROJECT_ROOT}/node_modules/stylelint/bin/stylelint.mjs"
 TOOLCHAIN_BIN=""
 NODE_PATH=""
 
@@ -74,15 +73,9 @@ if ! command -v node >/dev/null 2>&1; then
   exit 127
 fi
 
-if [ -f "$ROOT_STYLELINT" ]; then
-  TOOLCHAIN_BIN="$ROOT_STYLELINT"
-  NODE_PATH="${PROJECT_ROOT}/node_modules"
-elif [ -f "$CORE_STYLELINT" ]; then
-  TOOLCHAIN_BIN="$CORE_STYLELINT"
-  NODE_PATH="${DOCROOT_PATH}/core/node_modules"
-else
-  echo "Stylelint is not installed in ${DOCROOT}/core/node_modules or node_modules." >&2
-  echo "Enable corepack and run 'yarn install' in ${DOCROOT}/core, or install stylelint in the project root." >&2
+if ! resolve_node_tool "stylelint/bin/stylelint.mjs"; then
+  echo "Stylelint is not installed at the project root (${PROJECT_ROOT}/node_modules)." >&2
+  echo "Re-run the DDEV add-on installer and accept Node dependency installation, or install stylelint manually in the project root (npm install / yarn install)." >&2
   exit 127
 fi
 

--- a/commands/web/stylelint
+++ b/commands/web/stylelint
@@ -91,7 +91,7 @@ cd "$PROJECT_ROOT"
 
 # Hint about SCSS/Sass if present but not in default scan scope.
 if [ "$has_positional" = false ]; then
-  if find . -name '*.scss' -o -name '*.sass' 2>/dev/null | grep -q .; then
+  if find . \( -path ./node_modules -o -path ./vendor \) -prune -o \( -name '*.scss' -o -name '*.sass' \) -print -quit 2>/dev/null | grep -q .; then
     echo "Tip: SCSS/Sass files found but not included in the default scan." >&2
     echo "To lint SCSS, extend stylelint-config-standard-scss in your .stylelintrc.json" >&2
     echo "and pass SCSS paths explicitly, e.g.: ddev stylelint '**/*.scss'" >&2

--- a/commands/web/stylelint-fix
+++ b/commands/web/stylelint-fix
@@ -87,8 +87,10 @@ USAGE
   esac
 done
 
+# Override with DCQ_STYLELINT_GLOBS (space-separated, stylelint CLI syntax).
 if [ "$has_positional" = false ]; then
-  args+=('**/*.css' '**/*.scss' '**/*.sass')
+  read -ra _globs <<< "${DCQ_STYLELINT_GLOBS:-**/*.css}"
+  args+=("${_globs[@]}")
 fi
 
 cd "$PROJECT_ROOT"

--- a/commands/web/stylelint-fix
+++ b/commands/web/stylelint-fix
@@ -88,18 +88,9 @@ USAGE
 done
 
 if [ "$has_positional" = false ]; then
-  args+=('**/*.css')
+  args+=('**/*.css' '**/*.scss' '**/*.sass')
 fi
 
 cd "$PROJECT_ROOT"
-
-# Hint about SCSS/Sass if present but not in default scan scope.
-if [ "$has_positional" = false ]; then
-  if find . \( -path ./node_modules -o -path ./vendor \) -prune -o \( -name '*.scss' -o -name '*.sass' \) -print -quit 2>/dev/null | grep -q .; then
-    echo "Tip: SCSS/Sass files detected but not included in the default scan." >&2
-    echo "To add SCSS to default runs: extend stylelint-config-standard-scss in" >&2
-    echo "your .stylelintrc.json, then run: ddev stylelint-fix '**/*.css' '**/*.scss'" >&2
-  fi
-fi
 
 exec env NODE_PATH="$NODE_PATH" node "$TOOLCHAIN_BIN" --fix "${args[@]}"

--- a/commands/web/stylelint-fix
+++ b/commands/web/stylelint-fix
@@ -95,7 +95,7 @@ cd "$PROJECT_ROOT"
 
 # Hint about SCSS/Sass if present but not in default scan scope.
 if [ "$has_positional" = false ]; then
-  if find . -name '*.scss' -o -name '*.sass' 2>/dev/null | grep -q .; then
+  if find . \( -path ./node_modules -o -path ./vendor \) -prune -o \( -name '*.scss' -o -name '*.sass' \) -print -quit 2>/dev/null | grep -q .; then
     echo "Tip: SCSS/Sass files found but not included in the default scan." >&2
     echo "To lint SCSS, extend stylelint-config-standard-scss in your .stylelintrc.json" >&2
     echo "and pass SCSS paths explicitly, e.g.: ddev stylelint-fix '**/*.scss'" >&2

--- a/commands/web/stylelint-fix
+++ b/commands/web/stylelint-fix
@@ -96,9 +96,9 @@ cd "$PROJECT_ROOT"
 # Hint about SCSS/Sass if present but not in default scan scope.
 if [ "$has_positional" = false ]; then
   if find . \( -path ./node_modules -o -path ./vendor \) -prune -o \( -name '*.scss' -o -name '*.sass' \) -print -quit 2>/dev/null | grep -q .; then
-    echo "Tip: SCSS/Sass files found but not included in the default scan." >&2
-    echo "To lint SCSS, extend stylelint-config-standard-scss in your .stylelintrc.json" >&2
-    echo "and pass SCSS paths explicitly, e.g.: ddev stylelint-fix '**/*.scss'" >&2
+    echo "Tip: SCSS/Sass files detected but not included in the default scan." >&2
+    echo "To add SCSS to default runs: extend stylelint-config-standard-scss in" >&2
+    echo "your .stylelintrc.json, then run: ddev stylelint-fix '**/*.css' '**/*.scss'" >&2
   fi
 fi
 

--- a/commands/web/stylelint-fix
+++ b/commands/web/stylelint-fix
@@ -44,9 +44,9 @@ for arg in "$@"; do
   fi
   case "$arg" in
     --preview)
-      echo "Warning: --preview has been removed. Running --fix directly." >&2
-      echo "Use 'git diff' after 'ddev stylelint-fix' to review changes." >&2
-      continue
+      echo "Error: --preview has been removed." >&2
+      echo "Use 'ddev stylelint-fix' then 'git diff' to review changes." >&2
+      exit 1
       ;;
     -h|--help)
       cat <<'USAGE'
@@ -88,9 +88,18 @@ USAGE
 done
 
 if [ "$has_positional" = false ]; then
-  args+=('**/*.css' '**/*.scss' '**/*.sass')
+  args+=('**/*.css')
 fi
 
 cd "$PROJECT_ROOT"
+
+# Hint about SCSS/Sass if present but not in default scan scope.
+if [ "$has_positional" = false ]; then
+  if find . -name '*.scss' -o -name '*.sass' 2>/dev/null | grep -q .; then
+    echo "Tip: SCSS/Sass files found but not included in the default scan." >&2
+    echo "To lint SCSS, extend stylelint-config-standard-scss in your .stylelintrc.json" >&2
+    echo "and pass SCSS paths explicitly, e.g.: ddev stylelint-fix '**/*.scss'" >&2
+  fi
+fi
 
 exec env NODE_PATH="$NODE_PATH" node "$TOOLCHAIN_BIN" --fix "${args[@]}"

--- a/commands/web/stylelint-fix
+++ b/commands/web/stylelint-fix
@@ -17,6 +17,14 @@ if ! command -v node >/dev/null 2>&1; then
   exit 127
 fi
 
+# Stylelint requires Node.js 18+ (Array.prototype.findLastIndex).
+NODE_MAJOR="$(node -e 'console.log(process.versions.node.split(".")[0])')"
+if [ "${NODE_MAJOR:-0}" -lt 18 ]; then
+  echo "Error: Node.js $NODE_MAJOR is too old. Stylelint requires Node.js 18 or later." >&2
+  echo "Update nodejs_version in .ddev/config.yaml (recommended: \"20\") and run \"ddev restart\"." >&2
+  exit 1
+fi
+
 if ! resolve_node_tool "stylelint/bin/stylelint.mjs"; then
   echo "Stylelint is not installed at the project root (${PROJECT_ROOT}/node_modules)." >&2
   echo "Re-run the DDEV add-on installer and accept Node dependency installation," >&2

--- a/commands/web/stylelint-fix
+++ b/commands/web/stylelint-fix
@@ -4,6 +4,7 @@
 set -u
 
 source /mnt/ddev_config/commands/helpers/path-map.sh
+source /mnt/ddev_config/commands/helpers/node-toolchain.sh
 
 print_help() {
   cat <<'USAGE'
@@ -24,8 +25,6 @@ USAGE
 PROJECT_ROOT="/var/www/html"
 DOCROOT="${DCQ_DOCROOT:-web}"
 DOCROOT_PATH="${PROJECT_ROOT}/${DOCROOT}"
-CORE_STYLELINT="${DOCROOT_PATH}/core/node_modules/stylelint/bin/stylelint.mjs"
-ROOT_STYLELINT="${PROJECT_ROOT}/node_modules/stylelint/bin/stylelint.mjs"
 TOOLCHAIN_BIN=""
 NODE_PATH=""
 
@@ -91,15 +90,9 @@ if ! command -v node >/dev/null 2>&1; then
   exit 127
 fi
 
-if [ -f "$ROOT_STYLELINT" ]; then
-  TOOLCHAIN_BIN="$ROOT_STYLELINT"
-  NODE_PATH="${PROJECT_ROOT}/node_modules"
-elif [ -f "$CORE_STYLELINT" ]; then
-  TOOLCHAIN_BIN="$CORE_STYLELINT"
-  NODE_PATH="${DOCROOT_PATH}/core/node_modules"
-else
-  echo "Stylelint is not installed in ${DOCROOT}/core/node_modules or node_modules." >&2
-  echo "Enable corepack and run 'yarn install' in ${DOCROOT}/core, or install stylelint in the project root." >&2
+if ! resolve_node_tool "stylelint/bin/stylelint.mjs"; then
+  echo "Stylelint is not installed at the project root (${PROJECT_ROOT}/node_modules)." >&2
+  echo "Re-run the DDEV add-on installer and accept Node dependency installation, or install stylelint manually in the project root (npm install / yarn install)." >&2
   exit 127
 fi
 
@@ -342,9 +335,9 @@ if [ "$preview_mode" = true ]; then
     --exclude=./.git \
     --exclude=./.trunk \
     --exclude=./node_modules \
+    --exclude="./${DOCROOT}/*/node_modules" \
     --exclude=./vendor \
     --exclude=./dcq-reports \
-    --exclude=./${DOCROOT}/core/node_modules \
     --exclude='*/.git' \
     --exclude='*/.git/*' \
     . | (cd "$tmp_root" && tar -xf -)

--- a/commands/web/stylelint-fix
+++ b/commands/web/stylelint-fix
@@ -6,432 +6,91 @@ set -u
 source /mnt/ddev_config/commands/helpers/path-map.sh
 source /mnt/ddev_config/commands/helpers/node-toolchain.sh
 
-print_help() {
-  cat <<'USAGE'
-Usage: ddev stylelint-fix [args]
-
-Applies Stylelint fixes directly to files (matches standard stylelint --fix behavior).
-
-Use --preview to see a patch preview and confirm before applying fixes.
-This generates a patch in dcq-reports/ and prompts for confirmation.
-
-Examples:
-  ddev stylelint-fix                    # Apply fixes directly
-  ddev stylelint-fix --preview          # Preview and confirm before applying
-  ddev stylelint-fix path/to/file.css   # Fix specific file
-USAGE
-}
-
 PROJECT_ROOT="/var/www/html"
-DOCROOT="${DCQ_DOCROOT:-web}"
-DOCROOT_PATH="${PROJECT_ROOT}/${DOCROOT}"
 TOOLCHAIN_BIN=""
 NODE_PATH=""
 
-has_help=false
-has_version=false
-has_positional=false
-has_config=false
-has_ignore_path=false
-seen_double_dash=false
-explicit_paths=false
-preview_mode=false
-clean_args=()
-
-for arg in "$@"; do
-  if [ "$arg" = "--preview" ]; then
-    preview_mode=true
-    continue
-  fi
-  clean_args+=("$arg")
-done
-
-for arg in "${clean_args[@]}"; do
-  if [ "$seen_double_dash" = true ]; then
-    has_positional=true
-    explicit_paths=true
-    break
-  fi
-  case "$arg" in
-    --)
-      seen_double_dash=true
-      ;;
-    -h|--help)
-      has_help=true
-      ;;
-    -V|--version)
-      has_version=true
-      ;;
-    -c|--config|--config=*)
-      has_config=true
-      ;;
-    --ignore-path|--ignore-path=*)
-      has_ignore_path=true
-      ;;
-    -* )
-      ;;
-    *)
-      has_positional=true
-      explicit_paths=true
-      ;;
-  esac
-  if [ "$has_help" = true ] || [ "$has_version" = true ]; then
-    break
-  fi
-done
-
-if [ "$has_help" = true ]; then
-  print_help
-fi
+# --- Toolchain resolution (root only) ---
 
 if ! command -v node >/dev/null 2>&1; then
   echo "Node.js is not available in the DDEV web container." >&2
-  echo "Install the Drupal core JS toolchain (${DOCROOT}/core) to run Stylelint." >&2
   exit 127
 fi
 
 if ! resolve_node_tool "stylelint/bin/stylelint.mjs"; then
   echo "Stylelint is not installed at the project root (${PROJECT_ROOT}/node_modules)." >&2
-  echo "Re-run the DDEV add-on installer and accept Node dependency installation, or install stylelint manually in the project root (npm install / yarn install)." >&2
+  echo "Re-run the DDEV add-on installer and accept Node dependency installation," >&2
+  echo "or install stylelint manually (npm install / yarn install)." >&2
   exit 127
 fi
 
-if [ "$has_help" = true ]; then
-  node "$TOOLCHAIN_BIN" --help
-  exit $?
-fi
+# --- Argument translation ---
 
-if [ "$has_version" = true ]; then
-  node "$TOOLCHAIN_BIN" --version
-  exit $?
-fi
+args=()
+has_positional=false
+after_double_dash=false
+map_next=false
 
-normalize_path() {
-  local path="$1"
-  path="$(map_path "$path")"
-  if [[ "$path" == /var/www/html/* ]]; then
-    path="${path#/var/www/html/}"
+for arg in "$@"; do
+  if [ "$after_double_dash" = true ]; then
+    args+=("$(map_path "$arg")")
+    has_positional=true
+    continue
   fi
-  if [ "$DOCROOT" != "web" ] && [[ "$path" == web/* ]]; then
-    path="${DOCROOT}/${path#web/}"
-  fi
-  if [[ "$path" == "${DOCROOT}/"* ]]; then
-    echo "$path"
-    return
-  fi
-  if [[ "$path" == modules/* || "$path" == themes/* || "$path" == profiles/* ]]; then
-    echo "${DOCROOT}/$path"
-    return
-  fi
-  echo "$path"
-}
-
-find_stylelint_config() {
-  local path="$1"
-  local dir="$path"
-  if [[ "$dir" == /var/www/html/* ]]; then
-    dir="${dir#/var/www/html/}"
-  fi
-  if [ -f "${PROJECT_ROOT}/${dir}" ]; then
-    dir="$(dirname "$dir")"
-  fi
-  while [ "$dir" != "." ] && [ "$dir" != "/" ]; do
-    for candidate in .stylelintrc .stylelintrc.json .stylelintrc.yaml .stylelintrc.yml .stylelintrc.js; do
-      if [ -f "${PROJECT_ROOT}/${dir}/${candidate}" ]; then
-        echo "${PROJECT_ROOT}/${dir}/${candidate}"
-        return 0
-      fi
-    done
-    dir="$(dirname "$dir")"
-  done
-  return 1
-}
-
-TARGET_PREFIXES=()
-RAW_PATHS=()
-seen_double_dash=false
-args=("${clean_args[@]}")
-arg_count=${#args[@]}
-index=0
-while [ "$index" -lt "$arg_count" ]; do
-  arg="${args[$index]}"
-  if [ "$seen_double_dash" = true ]; then
-    RAW_PATHS+=("$arg")
-    index=$((index + 1))
+  if [ "$map_next" = true ]; then
+    args+=("$(map_path "$arg")")
+    map_next=false
     continue
   fi
   case "$arg" in
+    --preview)
+      echo "Warning: --preview has been removed. Running --fix directly." >&2
+      echo "Use 'git diff' after 'ddev stylelint-fix' to review changes." >&2
+      continue
+      ;;
+    -h|--help)
+      cat <<'USAGE'
+Usage: ddev stylelint-fix [args]
+
+Applies Stylelint --fix directly to files. All flags are passed through
+to stylelint. Use 'git diff' afterwards to review changes.
+
+Examples:
+  ddev stylelint-fix                    # Fix all custom code
+  ddev stylelint-fix path/to/file.css   # Fix specific file
+USAGE
+      exec env NODE_PATH="$NODE_PATH" node "$TOOLCHAIN_BIN" --help
+      ;;
+    -V|--version)
+      exec env NODE_PATH="$NODE_PATH" node "$TOOLCHAIN_BIN" --version
+      ;;
     --)
-      seen_double_dash=true
+      args+=("$arg")
+      after_double_dash=true
       ;;
-    -c|--config)
-      index=$((index + 1))
+    -c|--config|--ignore-path)
+      args+=("$arg")
+      map_next=true
       ;;
-    --config=*)
-      ;;
-    --ignore-path)
-      index=$((index + 1))
-      ;;
-    --ignore-path=*)
+    --config=*|--ignore-path=*)
+      flag="${arg%%=*}"
+      value="${arg#*=}"
+      args+=("${flag}=$(map_path "$value")")
       ;;
     -*)
+      args+=("$arg")
       ;;
     *)
-      RAW_PATHS+=("$arg")
+      args+=("$(map_path "$arg")")
+      has_positional=true
       ;;
   esac
-  index=$((index + 1))
 done
 
-if [ "${#RAW_PATHS[@]}" -gt 0 ]; then
-  for raw in "${RAW_PATHS[@]}"; do
-    TARGET_PREFIXES+=("$(normalize_path "$raw")")
-  done
-else
-  TARGET_PREFIXES+=("$DOCROOT")
+if [ "$has_positional" = false ]; then
+  args+=('**/*.css' '**/*.scss' '**/*.sass')
 fi
 
-FINAL_ARGS=()
-normalize_config_path() {
-  local path="$1"
-  path="$(map_path "$path")"
-  if [[ "$path" == /var/www/html/* ]]; then
-    path="${path#/var/www/html/}"
-  fi
-  if [ "$DOCROOT" != "web" ] && [[ "$path" == web/* ]]; then
-    path="${DOCROOT}/${path#web/}"
-  fi
-  echo "$path"
-}
-
-normalize_docroot_arg() {
-  local arg="$1"
-  arg="$(map_path "$arg")"
-  if [[ "$arg" == /var/www/html/* ]]; then
-    arg="${arg#/var/www/html/}"
-  fi
-  if [ "$DOCROOT" != "web" ] && [[ "$arg" == web/* ]]; then
-    arg="${DOCROOT}/${arg#web/}"
-  fi
-  if [[ "$arg" == "${DOCROOT}/"* ]]; then
-    arg="${arg#${DOCROOT}/}"
-  elif [ "$arg" = "$DOCROOT" ]; then
-    arg="."
-  fi
-  printf '%s' "$arg"
-}
-
-if [ "$explicit_paths" = true ]; then
-  args=("${clean_args[@]}")
-  arg_count=${#args[@]}
-  index=0
-  seen_double_dash=false
-  while [ "$index" -lt "$arg_count" ]; do
-    arg="${args[$index]}"
-    if [ "$seen_double_dash" = true ]; then
-      arg="$(normalize_docroot_arg "$arg")"
-      FINAL_ARGS+=("$arg")
-      index=$((index + 1))
-      continue
-    fi
-    case "$arg" in
-      --)
-        seen_double_dash=true
-        FINAL_ARGS+=("$arg")
-        ;;
-      -c|--config)
-        next_arg="${args[$((index + 1))]:-}"
-        FINAL_ARGS+=("$arg" "$(normalize_config_path "$next_arg")")
-        index=$((index + 1))
-        ;;
-      --ignore-path)
-        next_arg="${args[$((index + 1))]:-}"
-        FINAL_ARGS+=("$arg" "$(map_path "$next_arg")")
-        index=$((index + 1))
-        ;;
-      --config=*)
-        config_value="${arg#*=}"
-        FINAL_ARGS+=("--config=$(normalize_config_path "$config_value")")
-        ;;
-      --ignore-path=*)
-        ignore_value="${arg#*=}"
-        FINAL_ARGS+=("--ignore-path=$(map_path "$ignore_value")")
-        ;;
-      -*)
-        FINAL_ARGS+=("$arg")
-        ;;
-      *)
-        FINAL_ARGS+=("$(normalize_path "$arg")")
-        ;;
-    esac
-    index=$((index + 1))
-  done
-fi
-
-DEFAULT_FILES=()
-if [ "$explicit_paths" = false ]; then
-  if [ ! -d "$DOCROOT" ]; then
-    echo "Configured docroot '$DOCROOT' does not exist. Nothing to fix." >&2
-    exit 2
-  fi
-  while IFS= read -r file_path; do
-    DEFAULT_FILES+=("$file_path")
-  done < <(find "$DOCROOT" -path '*/node_modules/*' -prune -o -type f \( -name '*.css' -o -name '*.scss' -o -name '*.sass' \) -print)
-  if [ "${#DEFAULT_FILES[@]}" -eq 0 ]; then
-    echo "No CSS/SCSS/Sass files found under ${DOCROOT}. Nothing to fix." >&2
-    exit 2
-  fi
-fi
-
-FILES=()
-if [ "$explicit_paths" = false ]; then
-  FILES=("${DEFAULT_FILES[@]}")
-else
-  FILES=("${FINAL_ARGS[@]}")
-fi
-
-CONFIG_PATH=""
-if [ "$has_config" = false ]; then
-  if [ -f "${PROJECT_ROOT}/.stylelintrc.json" ]; then
-    CONFIG_PATH="${PROJECT_ROOT}/.stylelintrc.json"
-  else
-    for file_path in "${FILES[@]}"; do
-      if [[ "$file_path" == -* ]] || [ "$file_path" = "--" ]; then
-        continue
-      fi
-      if config_candidate="$(find_stylelint_config "$file_path")"; then
-        CONFIG_PATH="$config_candidate"
-        break
-      fi
-    done
-  fi
-  if [ -z "$CONFIG_PATH" ]; then
-    echo "Stylelint config file is missing. Create .stylelintrc.json in the project root (or a nearest config in the target paths), or pass --config." >&2
-    exit 2
-  fi
-  config_dir="$(dirname "$CONFIG_PATH")"
-  if [ -d "${config_dir}/node_modules" ]; then
-    NODE_PATH="${NODE_PATH}:${config_dir}/node_modules"
-  fi
-fi
-IGNORE_PATH_ARGS=()
-if [ "$has_ignore_path" = false ] && [ -f "${PROJECT_ROOT}/.stylelintignore" ]; then
-  IGNORE_PATH_ARGS=(--ignore-path "${PROJECT_ROOT}/.stylelintignore")
-fi
-
-# ============================================================================
-# PREVIEW MODE: Generate patch, show preview, prompt to apply
-# ============================================================================
-if [ "$preview_mode" = true ]; then
-  REPORT_DIR="dcq-reports"
-  mkdir -p "$REPORT_DIR"
-  PATCH_FILE="${REPORT_DIR}/_stylelint.patch"
-
-  tmp_root="$(mktemp -d)"
-  trap 'rm -rf "$tmp_root"' EXIT
-
-  cd "$PROJECT_ROOT"
-  tar -cf - \
-    --exclude=./.git \
-    --exclude=./.trunk \
-    --exclude=./node_modules \
-    --exclude="./${DOCROOT}/*/node_modules" \
-    --exclude=./vendor \
-    --exclude=./dcq-reports \
-    --exclude='*/.git' \
-    --exclude='*/.git/*' \
-    . | (cd "$tmp_root" && tar -xf -)
-
-  preview_cmd=(env "NODE_PATH=$NODE_PATH" node "$TOOLCHAIN_BIN")
-  if [ "$has_config" = false ]; then
-    preview_cmd+=(--config "$CONFIG_PATH" --config-basedir "$(dirname "$CONFIG_PATH")")
-  fi
-  preview_cmd+=("${IGNORE_PATH_ARGS[@]}")
-  preview_cmd+=(--fix)
-  
-  (cd "$tmp_root" && "${preview_cmd[@]}" "${FILES[@]}")
-  preview_exit=$?
-
-  if [ "${preview_exit:-0}" -eq 2 ]; then
-    echo "Stylelint preview failed (configuration error)." >&2
-    exit "$preview_exit"
-  fi
-
-  : > "${PATCH_FILE}.raw"
-  for prefix in "${TARGET_PREFIXES[@]}"; do
-    [ -z "$prefix" ] && continue
-    if [ ! -e "$PROJECT_ROOT/$prefix" ] && [ ! -e "$tmp_root/$prefix" ]; then
-      continue
-    fi
-    diff -ruN \
-      --exclude=.git \
-      --exclude='.git/*' \
-      "$PROJECT_ROOT/$prefix" "$tmp_root/$prefix" >> "${PATCH_FILE}.raw" || true
-  done
-
-  sed -E "s/diff -ruN( '--exclude=[^']+')+/diff -ruN/" "${PATCH_FILE}.raw" > "$PATCH_FILE"
-  rm -f "${PATCH_FILE}.raw"
-
-  change_count=$(grep -c '^diff -ruN ' "$PATCH_FILE" || true)
-  if [ "$change_count" -eq 0 ]; then
-    change_count=$(grep -c '^--- ' "$PATCH_FILE" || true)
-  fi
-
-  if [ "$change_count" -eq 0 ]; then
-    echo "No Stylelint fixes to apply. Preview reported no auto-fixable changes." >&2
-    exit 0
-  fi
-
-  echo "Preview: ${change_count} file(s) would change." >&2
-  echo "Patch: ${PATCH_FILE}" >&2
-
-  if [ -t 0 ]; then
-    printf "Apply these changes? [y/N] "
-    read -r reply
-    case "$reply" in
-      y|Y) ;;
-      *) echo "Not applying changes." >&2; exit 0 ;;
-    esac
-  else
-    echo "No TTY available. Not applying changes." >&2
-    exit 0
-  fi
-
-  # Apply fixes
-  cd "$PROJECT_ROOT"
-  fix_cmd=(env "NODE_PATH=$NODE_PATH" node "$TOOLCHAIN_BIN")
-  if [ "$has_config" = false ]; then
-    fix_cmd+=(--config "$CONFIG_PATH" --config-basedir "$(dirname "$CONFIG_PATH")")
-  fi
-  fix_cmd+=("${IGNORE_PATH_ARGS[@]}")
-  fix_cmd+=(--fix)
-  
-  "${fix_cmd[@]}" "${FILES[@]}"
-  fix_exit=$?
-
-  if [ "$fix_exit" -eq 0 ]; then
-    echo "Stylelint fixes applied." >&2
-  else
-    echo "Stylelint fixes applied; some issues may remain (exit ${fix_exit})." >&2
-  fi
-
-  echo "Running Stylelint to report any remaining issues..." >&2
-  ./.ddev/commands/web/stylelint "${clean_args[@]}"
-  check_exit=$?
-  exit "$check_exit"
-fi
-
-# ============================================================================
-# DEFAULT MODE: Apply fixes directly (standard stylelint --fix behavior)
-# ============================================================================
 cd "$PROJECT_ROOT"
 
-fix_cmd=(env "NODE_PATH=$NODE_PATH" node "$TOOLCHAIN_BIN")
-if [ "$has_config" = false ]; then
-  fix_cmd+=(--config "$CONFIG_PATH" --config-basedir "$(dirname "$CONFIG_PATH")")
-fi
-fix_cmd+=("${IGNORE_PATH_ARGS[@]}")
-fix_cmd+=(--fix)
-
-"${fix_cmd[@]}" "${FILES[@]}"
-exit $?
+exec env NODE_PATH="$NODE_PATH" node "$TOOLCHAIN_BIN" --fix "${args[@]}"

--- a/config.drupal-code-quality.yaml
+++ b/config.drupal-code-quality.yaml
@@ -1,0 +1,4 @@
+# Drupal Code Quality add-on configuration.
+web_environment:
+  # Default file patterns for ddev stylelint / ddev stylelint-fix (space-separated globs).
+  # - "DCQ_STYLELINT_GLOBS=**/*.css"

--- a/dcq-install.sh
+++ b/dcq-install.sh
@@ -279,8 +279,9 @@ prompt_choice() {
 }
 
 create_root_package_json() {
-  # Create a project-root package.json based on Drupal core's package.json.
-  # Uses PHP inside the DDEV container to read core dependencies.
+  # Create a minimal project-root package.json with only the packages DCQ needs.
+  # Reads curated package names from dcq-packages.json; resolves versions and
+  # engines.node from core's package.json.
   local ddev_cmd="$1"
   local app_root="$2"
   local container_package_json="/var/www/html/package.json"
@@ -290,12 +291,27 @@ create_root_package_json() {
   local status
 
   php_code=$(cat <<'PHP'
-$path = "__DOCROOT_COREDIR__/package.json";
-$data = json_decode(file_get_contents($path), true);
-if (!is_array($data)) {
+$corePath = "__DOCROOT_COREDIR__/package.json";
+$dcqPath = "/var/www/html/.ddev/drupal-code-quality/assets/dcq-packages.json";
+
+$core = json_decode(file_get_contents($corePath), true);
+if (!is_array($core)) {
   fwrite(STDERR, "Failed to read core package.json\n");
   exit(1);
 }
+$dcq = json_decode(file_get_contents($dcqPath), true);
+if (!is_array($dcq) || !isset($dcq["packages"])) {
+  fwrite(STDERR, "Failed to read dcq-packages.json\n");
+  exit(1);
+}
+
+$coreDeps = [];
+foreach (["dependencies", "devDependencies"] as $key) {
+  if (isset($core[$key]) && is_array($core[$key])) {
+    $coreDeps += $core[$key];
+  }
+}
+
 $projectName = null;
 $configPath = "/var/www/html/.ddev/config.yaml";
 if (is_readable($configPath)) {
@@ -309,25 +325,21 @@ if (is_readable($configPath)) {
     }
   }
 }
+
 $out = [
-  "name" => $projectName ?: ($data["name"] ?? "drupal-project"),
+  "name" => $projectName ?: "drupal-project",
   "private" => true,
 ];
-if (isset($data["description"])) {
-  $out["description"] = $data["description"];
+if (isset($core["engines"]["node"])) {
+  $out["engines"] = ["node" => $core["engines"]["node"]];
 }
-if (isset($data["license"])) {
-  $out["license"] = $data["license"];
+
+$devDeps = [];
+foreach ($dcq["packages"] as $pkg) {
+  $devDeps[$pkg] = $coreDeps[$pkg] ?? "";
 }
-if (isset($data["engines"])) {
-  $out["engines"] = $data["engines"];
-}
-if (isset($data["dependencies"])) {
-  $out["dependencies"] = $data["dependencies"];
-}
-if (isset($data["devDependencies"])) {
-  $out["devDependencies"] = $data["devDependencies"];
-}
+$out["devDependencies"] = $devDeps;
+
 echo json_encode($out, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
 PHP
   )
@@ -368,13 +380,14 @@ PHP
     fi
   fi
 
-  emit 'Created package.json from Drupal core devDependencies; review and customize as needed.\n'
+  emit 'Created package.json with DCQ dependencies (versions from Drupal core); review and customize as needed.\n'
   return 0
 }
 
 find_missing_node_deps() {
-  # Determine missing JS tooling deps by comparing root package.json to
-  # Drupal core + add-on config requirements (via a PHP helper in the container).
+  # Determine missing JS tooling deps by comparing root package.json to the
+  # curated list in dcq-packages.json (versions from core). Config files are
+  # also scanned as a safety net for user-added plugins not in the curated list.
   local ddev_cmd="$1"
   local php_code
   local php_payload
@@ -385,6 +398,7 @@ find_missing_node_deps() {
 $rootPath = "/var/www/html/package.json";
 $corePath = "__DOCROOT_COREDIR__/package.json";
 $assetsRoot = "/var/www/html/.ddev/drupal-code-quality/assets";
+$dcqPath = $assetsRoot . "/dcq-packages.json";
 
 function read_json_file(string $path): ?array {
   if (!is_readable($path)) {
@@ -458,13 +472,18 @@ if (!is_array($root) || !is_array($core)) {
 
 $rootDeps = merge_deps($root);
 $coreDeps = merge_deps($core);
-$required = $coreDeps;
 
-$basePackages = ["eslint", "prettier", "stylelint", "cspell"];
-foreach ($basePackages as $pkg) {
-  add_required($required, $pkg, $coreDeps);
+// Seed required set from the curated package list.
+$dcqData = read_json_file($dcqPath);
+$required = [];
+if (is_array($dcqData) && isset($dcqData["packages"])) {
+  foreach ($dcqData["packages"] as $pkg) {
+    $required[$pkg] = $coreDeps[$pkg] ?? "";
+  }
 }
 
+// Safety net: also scan config files for user-added plugins/extends not in
+// the curated list.
 $eslintConfigs = [
   $assetsRoot . "/.eslintrc.json",
   $assetsRoot . "/.eslintrc.jquery.json",
@@ -621,21 +640,26 @@ maybe_install_missing_root_deps() {
       deps_cmd+=" $(printf '%q' "$dep")"
     done
     if [ "$package_manager" = "npm" ]; then
-      cmd=( "$ddev_cmd" "exec" "bash" "-lc" "cd /var/www/html && npm install --save-dev --package-lock${deps_cmd}" )
+      # shellcheck disable=SC2086
+      cmd=( "$ddev_cmd" "npm" "install" "--save-dev" "--package-lock"${deps_cmd} )
       if ! run_command "${cmd[@]}"; then
         emit 'npm install --save-dev failed. You can retry manually.\n'
+        emit_dcq_package_list "npm"
         return 1
       fi
       emit 'Node dependencies added (project root).\n'
-      cmd=( "$ddev_cmd" "exec" "bash" "-lc" "cd /var/www/html && npm install --package-lock" )
+      cmd=( "$ddev_cmd" "npm" "install" "--package-lock" )
       if ! run_command "${cmd[@]}"; then
         emit 'npm install failed. You can retry manually.\n'
+        emit_dcq_package_list "npm"
         return 1
       fi
     else
-      cmd=( "$ddev_cmd" "exec" "bash" "-lc" "cd /var/www/html && yarn add -D${deps_cmd}" )
+      # shellcheck disable=SC2086
+      cmd=( "$ddev_cmd" "yarn" "add" "-D"${deps_cmd} )
       if ! run_command "${cmd[@]}"; then
         emit 'yarn add failed. You can retry manually.\n'
+        emit_dcq_package_list "yarn"
         return 1
       fi
       emit 'Node dependencies added (project root).\n'
@@ -710,15 +734,15 @@ emit_node_install_command() {
 
   if [ -n "$deps_cmd" ]; then
     if [ "$package_manager" = "npm" ]; then
-      cmd="ddev exec bash -lc \"cd /var/www/html && npm install --save-dev${deps_cmd}\""
+      cmd="ddev npm install --save-dev${deps_cmd}"
     else
-      cmd="ddev exec bash -lc \"cd /var/www/html && yarn add -D${deps_cmd}\""
+      cmd="ddev yarn add -D${deps_cmd}"
     fi
   else
     if [ "$package_manager" = "npm" ]; then
-      cmd="ddev exec bash -lc \"cd /var/www/html && npm install\""
+      cmd="ddev npm install"
     else
-      cmd="ddev exec bash -lc \"cd /var/www/html && yarn install\""
+      cmd="ddev yarn install"
     fi
   fi
 
@@ -726,6 +750,35 @@ emit_node_install_command() {
     emit 'No project package.json found. The install requires one at the project root.\n'
   fi
   emit 'Run:\n  %s\n' "$cmd"
+}
+
+emit_dcq_package_list() {
+  # Print the curated DCQ package list and a manual install command.
+  # Usage: emit_dcq_package_list <package_manager>
+  local package_manager="${1:-npm}"
+  local assets_dir
+  assets_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/drupal-code-quality/assets"
+  local dcq_packages_file="${assets_dir}/dcq-packages.json"
+  local packages=""
+
+  if [ -f "$dcq_packages_file" ]; then
+    # Extract package names from the JSON array (lines containing only a quoted
+    # string, no colon — excludes keys like "packages" and "_comment").
+    packages="$(grep -v ':' "$dcq_packages_file" | grep '"' | sed 's/.*"\([^"]*\)".*/\1/' | tr '\n' ' ')"
+  fi
+
+  if [ -z "$packages" ]; then
+    packages="cspell eslint eslint-config-airbnb-base eslint-config-prettier eslint-plugin-import eslint-plugin-jsdoc eslint-plugin-no-jquery eslint-plugin-prettier eslint-plugin-yml prettier stylelint stylelint-config-standard stylelint-order stylelint-prettier"
+  fi
+
+  emit '\nDCQ requires these npm packages for code quality tooling:\n'
+  emit '  %s\n' "$packages"
+  emit '\nTo install manually:\n'
+  if [ "$package_manager" = "yarn" ]; then
+    emit '  ddev yarn add -D %s\n' "$packages"
+  else
+    emit '  ddev npm install --save-dev %s\n' "$packages"
+  fi
 }
 
 prompt_yes_no() {
@@ -1092,6 +1145,64 @@ merge_phpcs_config() {
 
   # Cleanup
   rm -f "$tmp" "$merged"
+}
+
+merge_stylelint_config() {
+  # Merge .stylelintrc.dcq.json amendments into .stylelintrc.json.
+  # Adds top-level keys from the amendment file that are missing in the target.
+  local stylelint_dcq_source="$1"
+  local target="$2"
+  local python_bin=""
+
+  if [ ! -f "$stylelint_dcq_source" ]; then
+    return 0
+  fi
+  if [ ! -f "$target" ]; then
+    return 0
+  fi
+
+  if command_available python3; then
+    python_bin="python3"
+  elif command_available python; then
+    python_bin="python"
+  else
+    emit 'Warning: python not available; unable to merge stylelint amendments.\n'
+    return 1
+  fi
+
+  "$python_bin" - "$target" "$stylelint_dcq_source" <<'PY'
+import json
+import sys
+
+target_path, amendment_path = sys.argv[1:3]
+
+with open(target_path, encoding="utf-8") as f:
+    content = f.read()
+lines = content.splitlines()
+if lines and lines[0].strip() == "#ddev-generated":
+    content = "\n".join(lines[1:])
+target = json.loads(content)
+
+with open(amendment_path, encoding="utf-8") as f:
+    content = f.read()
+lines = content.splitlines()
+if lines and lines[0].strip() == "#ddev-generated":
+    content = "\n".join(lines[1:])
+amendment = json.loads(content)
+
+changed = False
+for key, value in amendment.items():
+    if key.startswith("_"):
+        continue
+    if key not in target:
+        target[key] = value
+        changed = True
+
+if changed:
+    with open(target_path, "w", encoding="utf-8") as f:
+        json.dump(target, f, indent=4, ensure_ascii=False)
+        f.write("\n")
+PY
 }
 
 append_unique_lines_from_file() {
@@ -1916,7 +2027,9 @@ for tool in phpstan phpcs phpcbf; do
   fi
 done
 
-if [ "${#missing_tools[@]}" -gt 0 ]; then
+if [ "${#missing_tools[@]}" -eq 0 ]; then
+  emit 'PHP dev tools already present (phpstan, phpcs, phpcbf). No action needed.\n'
+elif [ "${#missing_tools[@]}" -gt 0 ]; then
   composer_json="${app_root%/}/composer.json"
   has_core_dev=0
   if [ -f "$composer_json" ] && grep -q '"drupal/core-dev"' "$composer_json"; then
@@ -2049,7 +2162,6 @@ fi
 script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 if [[ "$script_path" == */.ddev/dcq-install.sh ]]; then
   rm -f "$script_path"
-  emit 'Removed %s after install.\n' "$script_path"
 fi
 
 emit '\n==> Phase 2: Copy Drupal.org GitLab CI template configs and shims\n'
@@ -2079,6 +2191,9 @@ while IFS= read -r -d '' source; do
     continue
   fi
   if [[ "$rel" == config-amendments/* ]]; then
+    continue
+  fi
+  if [[ "$rel" == assets/dcq-packages.json ]]; then
     continue
   fi
   is_shim=0
@@ -2244,6 +2359,18 @@ done < <(find "$addon_root" -type f -print0)
 append_unique_lines_from_file \
   "${app_root%/}/.prettierignore" \
   "${addon_root}/config-amendments/.prettierignore.dcq"
+
+# Merge stylelint DCQ amendments (runs post-loop so it applies even when the
+# base config was unchanged and skipped by the copy loop).
+if [ -f "${app_root%/}/.stylelintrc.json" ]; then
+  stylelint_dcq_source="${addon_root}/config-amendments/.stylelintrc.dcq.json"
+  merge_stylelint_config "$stylelint_dcq_source" "${app_root%/}/.stylelintrc.json"
+fi
+
+# Clean up dcq-packages.json from project root if left by a prior install.
+if [ -f "${app_root%/}/dcq-packages.json" ]; then
+  rm -f "${app_root%/}/dcq-packages.json"
+fi
 
 if [ "$copy_changed" -eq 0 ] && [ "$copy_skipped" -eq 0 ]; then
   emit 'All files already match; no changes.\n'
@@ -2515,17 +2642,18 @@ if [ "$core_package_json_present" -eq 1 ]; then
               ensure_root_yarnrc "$app_root"
             fi
           fi
-          emit 'Installing JS deps in project root using %s.\n' "${root_pm:-npm}"
+          emit 'Installing JS deps in project root using %s (this may take several minutes).\n' "${root_pm:-npm}"
           if [ "${root_pm:-npm}" = "npm" ]; then
-            cmd=( "$ddev_cmd" "exec" "bash" "-lc" "cd /var/www/html && npm install" )
+            cmd=( "$ddev_cmd" "npm" "install" )
           else
-            cmd=( "$ddev_cmd" "exec" "bash" "-lc" "cd /var/www/html && yarn install" )
+            cmd=( "$ddev_cmd" "yarn" "install" )
           fi
           if run_command "${cmd[@]}"; then
             node_install_done=1
           else
             emit 'JS dependency install failed. You can retry manually:\n'
-            emit '  ddev exec bash -lc "cd /var/www/html && %s install"\n' "${root_pm:-npm}"
+            emit '  ddev %s install\n' "${root_pm:-npm}"
+            emit_dcq_package_list "${root_pm:-npm}"
           fi
         fi
         if [ "$node_install_done" -eq 1 ]; then
@@ -2739,6 +2867,8 @@ print_install_summary() {
 
   if [ "$php_deps_status" = "installed" ]; then
     emit '  - PHP dev tools (PHPStan, PHPCS, etc.)\n'
+  elif [ "$php_deps_status" = "present" ]; then
+    emit '  - PHP dev tools: already present (skipped)\n'
   elif [ "$php_deps_status" = "failed" ]; then
     emit '  - PHP dev tools: FAILED (see warning below)\n'
   else
@@ -2747,6 +2877,8 @@ print_install_summary() {
 
   if [ "$node_status" = "root" ]; then
     emit '  - Node toolchain (ESLint, Prettier, Stylelint)\n'
+  elif [ "$node_status" = "present" ]; then
+    emit '  - Node toolchain: already present (skipped)\n'
   else
     emit '  - Node toolchain: NOT installed\n'
   fi
@@ -2766,13 +2898,14 @@ print_install_summary() {
     emit '     (see error output above), then run:\n'
     emit '     ddev composer require --dev drupal/core-dev --with-all-dependencies\n'
     step_num=$((step_num + 1))
-  elif [ "$php_deps_status" != "installed" ]; then
+  elif [ "$php_deps_status" != "installed" ] && [ "$php_deps_status" != "present" ]; then
     emit '  %s. Install PHP tools: ddev composer require --dev drupal/core-dev\n' "$step_num"
     step_num=$((step_num + 1))
   fi
 
-  if [ "$node_status" != "root" ]; then
-    emit '  %s. Install Node tools: ddev exec bash -lc "cd /var/www/html && npm install"\n' "$step_num"
+  if [ "$node_status" != "root" ] && [ "$node_status" != "present" ]; then
+    emit '  %s. Install Node tools:\n' "$step_num"
+    emit_dcq_package_list "$pkg_mgr"
     step_num=$((step_num + 1))
   fi
 
@@ -2792,12 +2925,12 @@ print_install_summary() {
 
   if [ "$has_scss" = "accepted" ]; then
     emit '\n'
-    emit 'SCSS support — complete these steps to finish setup:\n'
-    emit '  1. Install the SCSS config package:\n'
+    emit 'SCSS Setup (complete these steps to finish):\n'
+    emit '  a. Install the SCSS config package:\n'
     emit '       %s\n' "$scss_install_cmd"
-    emit '  2. Update .stylelintrc.json — replace "stylelint-config-standard" with\n'
+    emit '  b. Update .stylelintrc.json — replace "stylelint-config-standard" with\n'
     emit '     "stylelint-config-standard-scss" in the "extends" array.\n'
-    emit '  3. Run: ddev restart\n'
+    emit '  c. Run: ddev restart\n'
     emit '  (SCSS scan globs have already been configured in\n'
     emit '   .ddev/config.drupal-code-quality.yaml)\n'
   elif [ "$has_scss" = "true" ] || [ "$has_scss" = "declined" ]; then
@@ -2810,14 +2943,14 @@ print_install_summary() {
     fi
     emit 'To enable SCSS linting later:\n'
     emit '  - Re-run the installer interactively and accept SCSS setup, or:\n'
-    emit '  1. Install the SCSS config package:\n'
+    emit '  a. Install the SCSS config package:\n'
     emit '       %s\n' "$scss_install_cmd"
-    emit '  2. Update .stylelintrc.json — replace "stylelint-config-standard" with\n'
+    emit '  b. Update .stylelintrc.json — replace "stylelint-config-standard" with\n'
     emit '     "stylelint-config-standard-scss" in the "extends" array.\n'
-    emit '  3. In .ddev/config.drupal-code-quality.yaml, uncomment and update the\n'
+    emit '  c. In .ddev/config.drupal-code-quality.yaml, uncomment and update the\n'
     emit '     DCQ_STYLELINT_GLOBS line under web_environment:\n'
     emit '       - "DCQ_STYLELINT_GLOBS=**/*.css **/*.scss"\n'
-    emit '  4. Run: ddev restart\n'
+    emit '  d. Run: ddev restart\n'
   fi
 
   emit '\n'
@@ -2825,17 +2958,31 @@ print_install_summary() {
   emit '===============================================================\n'
 }
 
-# Determine summary statuses
+# Determine summary statuses — report actual state, not just what this run did.
 php_deps_summary="skipped"
 if [ "${php_deps_failed:-0}" -eq 1 ]; then
   php_deps_summary="failed"
 elif [ "${should_install:-0}" -eq 1 ]; then
   php_deps_summary="installed"
 fi
+# Check if tools are actually present regardless of what happened in this run.
+if [ "$php_deps_summary" = "skipped" ]; then
+  _all_php_present=1
+  for _tool in phpstan phpcs phpcbf; do
+    if [ ! -e "${vendor_bin}/${_tool}" ]; then _all_php_present=0; break; fi
+  done
+  if [ "$_all_php_present" -eq 1 ]; then
+    php_deps_summary="present"
+  fi
+fi
 
 node_summary="skipped"
 if [ -n "${node_target_choice:-}" ] && [ "$node_target_choice" = "root" ]; then
   node_summary="root"
+fi
+# Check if Node toolchain is actually present regardless of what happened in this run.
+if [ "$node_summary" = "skipped" ] && node_toolchain_present "$app_root"; then
+  node_summary="present"
 fi
 
 ide_summary="${ide_mode:-skip}"

--- a/dcq-install.sh
+++ b/dcq-install.sh
@@ -139,7 +139,7 @@ create_root_package_json() {
   local status
 
   php_code=$(cat <<'PHP'
-$path = "__DOCROOT_CORE__/package.json";
+$path = "__DOCROOT_COREDIR__/package.json";
 $data = json_decode(file_get_contents($path), true);
 if (!is_array($data)) {
   fwrite(STDERR, "Failed to read core package.json\n");
@@ -180,7 +180,7 @@ if (isset($data["devDependencies"])) {
 echo json_encode($out, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
 PHP
   )
-  php_code="${php_code//__DOCROOT_CORE__/${DOCROOT_CORE}}"
+  php_code="${php_code//__DOCROOT_COREDIR__/${DOCROOT_COREDIR}}"
   php_payload="$(printf '%s' "$php_code" | base64 | tr -d '\n')"
 
   # Use bash -lc so the php -r argument stays quoted; ddev exec can reparse
@@ -232,7 +232,7 @@ find_missing_node_deps() {
 
   php_code=$(cat <<'PHP'
 $rootPath = "/var/www/html/package.json";
-$corePath = "__DOCROOT_CORE__/package.json";
+$corePath = "__DOCROOT_COREDIR__/package.json";
 $assetsRoot = "/var/www/html/.ddev/drupal-code-quality/assets";
 
 function read_json_file(string $path): ?array {
@@ -403,7 +403,7 @@ foreach ($missing as $name => $version) {
 }
 PHP
   )
-  php_code="${php_code//__DOCROOT_CORE__/${DOCROOT_CORE}}"
+  php_code="${php_code//__DOCROOT_COREDIR__/${DOCROOT_COREDIR}}"
   php_payload="$(printf '%s' "$php_code" | base64 | tr -d '\n')"
 
   # Use bash -lc so the php -r argument stays quoted; ddev exec can reparse
@@ -1578,11 +1578,9 @@ PY
 }
 
 node_toolchain_present() {
-  # Detect installed eslint tooling in either root or core node_modules.
+  # Detect installed eslint tooling at the project root (root-only policy).
   local app_root="$1"
   local paths=(
-    "$app_root/${DCQ_DOCROOT}/core/node_modules/.bin/eslint"
-    "$app_root/${DCQ_DOCROOT}/core/node_modules/eslint/bin/eslint.js"
     "$app_root/node_modules/.bin/eslint"
     "$app_root/node_modules/eslint/bin/eslint.js"
   )
@@ -1675,7 +1673,7 @@ fi
 dcq_docroot="$(detect_docroot "${app_root%/}/.ddev/config.yaml")"
 DCQ_DOCROOT="$dcq_docroot"
 DOCROOT_CONTAINER="/var/www/html/${DCQ_DOCROOT}"
-DOCROOT_CORE="${DOCROOT_CONTAINER}/core"
+DOCROOT_COREDIR="${DOCROOT_CONTAINER}/core"
 docroot_file="${app_root%/}/.ddev/.dcq-docroot"
 if [ -f "$docroot_file" ]; then
   if ! grep -Fxq "$DCQ_DOCROOT" "$docroot_file"; then
@@ -2111,6 +2109,19 @@ if [ "$core_package_json_present" -eq 1 ]; then
   if [ -z "$node_mode_raw" ] && [ "$node_toolchain_existing" -eq 1 ]; then
     node_mode_raw="skip"
     skip_due_to_existing_toolchain=1
+  fi
+
+  # Detect legacy core-only installs that need migration to project root.
+  if [ -z "$node_mode_raw" ] && [ "$node_toolchain_existing" -eq 0 ]; then
+    core_dir="${DCQ_DOCROOT}/core"
+    legacy_core_nm="${app_root}/${core_dir}/node_modules"
+    if [ -e "${legacy_core_nm}/.bin/eslint" ] || \
+       [ -e "${legacy_core_nm}/eslint/bin/eslint.js" ]; then
+      emit 'Legacy core-only Node toolchain detected. The add-on now requires tooling at the project root.\n'
+      if [ "$non_interactive" -eq 1 ]; then
+        node_mode_raw="root"
+      fi
+    fi
   fi
 
   if [ "$node_mode_raw" != "skip" ] || [ "$skip_due_to_existing_toolchain" -eq 1 ]; then

--- a/dcq-install.sh
+++ b/dcq-install.sh
@@ -2185,12 +2185,14 @@ if [ "$core_package_json_present" -eq 1 ]; then
     scss_install_scss="false"
     if detect_scss_files "$app_root"; then
       # Check if SCSS support is already fully configured.
-      # Both conditions must be true: stylelint config references scss AND
+      # Both conditions must be true: a stylelint config references scss AND
       # the DDEV env var includes scss globs.
-      stylelintrc="${app_root%/}/.stylelintrc.json"
       scss_has_config=false
       scss_has_globs=false
-      if [ -f "$stylelintrc" ] && grep -q 'scss' "$stylelintrc"; then
+      if find "$app_root" -maxdepth 4 \
+           -type d \( -name node_modules -o -name vendor -o -name .git -o -name .ddev \) -prune \
+           -o -name '.stylelintrc*' -type f -print0 2>/dev/null \
+         | xargs -0 grep -lq 'scss' 2>/dev/null; then
         scss_has_config=true
       fi
       if grep -rlq 'DCQ_STYLELINT_GLOBS.*scss' "${app_root%/}/.ddev/"*.yaml 2>/dev/null; then
@@ -2204,7 +2206,7 @@ if [ "$core_package_json_present" -eq 1 ]; then
       if [ "$scss_already_configured" = true ]; then
         scss_detected="configured"
         emit 'SCSS files detected — SCSS support appears to be configured already.\n'
-      elif [ "$non_interactive" -eq 0 ] && [ "${PROMPT_AVAILABLE:-0}" -eq 1 ]; then
+      elif [ "$non_interactive" -eq 0 ] && [ "$recommended_mode" -eq 0 ] && [ "${PROMPT_AVAILABLE:-0}" -eq 1 ]; then
         emit '\nYour project contains SCSS files, but Stylelint is currently configured\n'
         emit 'to check CSS only. Would you like to set up SCSS support? [Y/n] '
         scss_answer=""
@@ -2607,10 +2609,12 @@ configs_copied="${copy_changed:-0}"
 # Detect SCSS if not already done during Node deps phase (e.g. Node was skipped).
 if [ "$scss_detected" = "false" ] && detect_scss_files "$app_root"; then
   # Check if SCSS support is already fully configured (both config and globs).
-  stylelintrc="${app_root%/}/.stylelintrc.json"
   scss_has_config=false
   scss_has_globs=false
-  if [ -f "$stylelintrc" ] && grep -q 'scss' "$stylelintrc"; then
+  if find "$app_root" -maxdepth 4 \
+       -type d \( -name node_modules -o -name vendor -o -name .git -o -name .ddev \) -prune \
+       -o -name '.stylelintrc*' -type f -print0 2>/dev/null \
+     | xargs -0 grep -lq 'scss' 2>/dev/null; then
     scss_has_config=true
   fi
   if grep -rlq 'DCQ_STYLELINT_GLOBS.*scss' "${app_root%/}/.ddev/"*.yaml 2>/dev/null; then

--- a/dcq-install.sh
+++ b/dcq-install.sh
@@ -1593,6 +1593,14 @@ node_toolchain_present() {
   return 1
 }
 
+detect_scss_files() {
+  # Check if the project contains .scss or .sass files (excluding dependencies).
+  local search_root="$1"
+  find "$search_root" \
+    -type d \( -name node_modules -o -name vendor -o -name .git -o -name .ddev \) -prune \
+    -o -type f \( -name '*.scss' -o -name '*.sass' \) -print -quit 2>/dev/null | grep -q .
+}
+
 run_command() {
   # Echo and execute a command (simple transparency for users).
   # In interactive installs we route output through a small sanitizer to drop
@@ -2074,6 +2082,9 @@ fi
 # Expand CSpell configuration with project-specific settings
 expand_cspell_config "$app_root"
 
+scss_detected="false"
+scss_install_scss="false"
+
 emit '\n==> Phase 3: JS toolchain dependencies\n'
 core_package_json="${app_root%/}/${DCQ_DOCROOT}/core/package.json"
 core_package_json_present=0
@@ -2174,6 +2185,47 @@ if [ "$core_package_json_present" -eq 1 ]; then
         missing_node_deps=""
       fi
     fi
+    # Detect SCSS files before Node install so we can offer to set up support.
+    scss_install_scss="false"
+    if detect_scss_files "$app_root"; then
+      # Check if SCSS support is already fully configured.
+      # Both conditions must be true: stylelint config references scss AND
+      # the DDEV env var includes scss globs.
+      stylelintrc="${app_root%/}/.stylelintrc.json"
+      scss_has_config=false
+      scss_has_globs=false
+      if [ -f "$stylelintrc" ] && grep -q 'scss' "$stylelintrc"; then
+        scss_has_config=true
+      fi
+      if grep -rlq 'DCQ_STYLELINT_GLOBS.*scss' "${app_root%/}/.ddev/"*.yaml 2>/dev/null; then
+        scss_has_globs=true
+      fi
+      scss_already_configured=false
+      if [ "$scss_has_config" = true ] && [ "$scss_has_globs" = true ]; then
+        scss_already_configured=true
+      fi
+
+      if [ "$scss_already_configured" = true ]; then
+        scss_detected="configured"
+        emit 'SCSS files detected — SCSS support appears to be configured already.\n'
+      elif [ "$non_interactive" -eq 0 ] && [ "${PROMPT_AVAILABLE:-0}" -eq 1 ]; then
+        emit '\nYour project contains SCSS files, but Stylelint is currently configured\n'
+        emit 'to check CSS only. Would you like to set up SCSS support? [Y/n] '
+        scss_answer=""
+        if IFS= read -r -u "$PROMPT_IN_FD" scss_answer; then
+          scss_answer="$(printf '%s' "$scss_answer" | tr -d '\r\n')"
+        fi
+        if [ -z "$scss_answer" ] || [ "$scss_answer" = "y" ] || [ "$scss_answer" = "Y" ]; then
+          scss_install_scss="true"
+          scss_detected="pending"
+        else
+          scss_detected="declined"
+        fi
+      else
+        scss_detected="true"
+      fi
+    fi
+
     if [ "$node_mode" != "skip" ]; then
       emit 'Preparing JS toolchain install.\n'
       if ! command_available "$ddev_cmd"; then
@@ -2257,6 +2309,26 @@ if [ "$core_package_json_present" -eq 1 ]; then
       fi
     fi
   fi
+fi
+
+# If user accepted SCSS support, write the SCSS globs to the add-on config.
+# The package install command and config change are shown in the summary
+# so the user can see them all together and handle version conflicts.
+if [ "$scss_install_scss" = "true" ]; then
+  dcq_config="${app_root%/}/.ddev/config.drupal-code-quality.yaml"
+  cat > "$dcq_config" <<'DCQYAML'
+# Drupal Code Quality add-on configuration.
+web_environment:
+  - "DCQ_STYLELINT_GLOBS=**/*.css **/*.scss"
+DCQYAML
+  emit 'Updated .ddev/config.drupal-code-quality.yaml with SCSS globs.\n'
+  emit 'Note: there are manual steps to complete after install — look for the\n'
+  emit 'SCSS instructions in the install summary at the end.\n'
+  if [ "${PROMPT_AVAILABLE:-0}" -eq 1 ]; then
+    emit 'Press Enter to continue...'
+    IFS= read -r -u "$PROMPT_IN_FD" _ || true
+  fi
+  scss_detected="accepted"
 fi
 
 emit '\n==> Optional: .gitignore update\n'
@@ -2428,6 +2500,8 @@ print_install_summary() {
   local node_status="$2"
   local ide_status="$3"
   local configs_count="$4"
+  local has_scss="$5"
+  local pkg_mgr="${6:-npm}"
 
   emit '\n'
   emit '===============================================================\n'
@@ -2477,6 +2551,43 @@ print_install_summary() {
     emit '  %s. Setup VS Code: see .ddev/drupal-code-quality/ide-settings/vscode/README.md\n' "$step_num"
   fi
 
+  local scss_install_cmd
+  if [ "$pkg_mgr" = "yarn" ]; then
+    scss_install_cmd="ddev yarn add --dev stylelint-config-standard-scss"
+  else
+    scss_install_cmd="ddev npm install --save-dev stylelint-config-standard-scss"
+  fi
+
+  if [ "$has_scss" = "accepted" ]; then
+    emit '\n'
+    emit 'SCSS support — complete these steps to finish setup:\n'
+    emit '  1. Install the SCSS config package:\n'
+    emit '       %s\n' "$scss_install_cmd"
+    emit '  2. Update .stylelintrc.json — replace "stylelint-config-standard" with\n'
+    emit '     "stylelint-config-standard-scss" in the "extends" array.\n'
+    emit '  3. Run: ddev restart\n'
+    emit '  (SCSS scan globs have already been configured in\n'
+    emit '   .ddev/config.drupal-code-quality.yaml)\n'
+  elif [ "$has_scss" = "true" ] || [ "$has_scss" = "declined" ]; then
+    emit '\n'
+    if [ "$has_scss" = "declined" ]; then
+      emit 'SCSS support was not installed. Stylelint will only check CSS files.\n'
+    else
+      emit 'SCSS files were detected but SCSS support was not configured.\n'
+      emit 'Stylelint will only check CSS files.\n'
+    fi
+    emit 'To enable SCSS linting later:\n'
+    emit '  - Re-run the installer interactively and accept SCSS setup, or:\n'
+    emit '  1. Install the SCSS config package:\n'
+    emit '       %s\n' "$scss_install_cmd"
+    emit '  2. Update .stylelintrc.json — replace "stylelint-config-standard" with\n'
+    emit '     "stylelint-config-standard-scss" in the "extends" array.\n'
+    emit '  3. In .ddev/config.drupal-code-quality.yaml, uncomment and update the\n'
+    emit '     DCQ_STYLELINT_GLOBS line under web_environment:\n'
+    emit '       - "DCQ_STYLELINT_GLOBS=**/*.css **/*.scss"\n'
+    emit '  4. Run: ddev restart\n'
+  fi
+
   emit '\n'
   emit 'More info: https://github.com/UltraBob/ddev-drupal-code-quality\n'
   emit '===============================================================\n'
@@ -2497,4 +2608,23 @@ ide_summary="${ide_mode:-skip}"
 
 configs_copied="${copy_changed:-0}"
 
-print_install_summary "$php_deps_summary" "$node_summary" "$ide_summary" "$configs_copied"
+# Detect SCSS if not already done during Node deps phase (e.g. Node was skipped).
+if [ "$scss_detected" = "false" ] && detect_scss_files "$app_root"; then
+  # Check if SCSS support is already fully configured (both config and globs).
+  stylelintrc="${app_root%/}/.stylelintrc.json"
+  scss_has_config=false
+  scss_has_globs=false
+  if [ -f "$stylelintrc" ] && grep -q 'scss' "$stylelintrc"; then
+    scss_has_config=true
+  fi
+  if grep -rlq 'DCQ_STYLELINT_GLOBS.*scss' "${app_root%/}/.ddev/"*.yaml 2>/dev/null; then
+    scss_has_globs=true
+  fi
+  if [ "$scss_has_config" = true ] && [ "$scss_has_globs" = true ]; then
+    scss_detected="configured"
+  else
+    scss_detected="true"
+  fi
+fi
+
+print_install_summary "$php_deps_summary" "$node_summary" "$ide_summary" "$configs_copied" "$scss_detected" "${root_pm:-npm}"

--- a/dcq-install.sh
+++ b/dcq-install.sh
@@ -1278,7 +1278,7 @@ merge_json_settings() {
     return 2
   fi
 
-  if ! "$python_bin" - "$existing" "$template" "$dest" <<'PY'
+  "$python_bin" - "$existing" "$template" "$dest" <<'PY'
 import copy
 import json
 import sys
@@ -1403,9 +1403,7 @@ with open(dest_path, "w", encoding="utf-8") as f:
     json.dump(existing, f, indent=2, ensure_ascii=True)
     f.write("\n")
 PY
-  then
-    return 1
-  fi
+  return $?
 }
 
 merge_json_extensions() {
@@ -1423,7 +1421,7 @@ merge_json_extensions() {
     return 2
   fi
 
-  if ! "$python_bin" - "$existing" "$template" "$dest" <<'PY'
+  "$python_bin" - "$existing" "$template" "$dest" <<'PY'
 import json
 import sys
 
@@ -1572,9 +1570,7 @@ with open(dest_path, "w", encoding="utf-8") as f:
     json.dump(merged, f, indent=2, ensure_ascii=True)
     f.write("\n")
 PY
-  then
-    return 1
-  fi
+  return $?
 }
 
 node_toolchain_present() {

--- a/dcq-install.sh
+++ b/dcq-install.sh
@@ -55,6 +55,157 @@ detect_docroot() {
   printf '%s' "$value"
 }
 
+detect_nodejs_version() {
+  # Read the nodejs_version value from .ddev/config.yaml.
+  # Returns the version string (e.g. "16", "20") or empty if not set.
+  local config_path="$1"
+  local value=""
+
+  if [ -f "$config_path" ]; then
+    value="$(awk -F: '/^[[:space:]]*nodejs_version:/ {
+      val=$2
+      sub(/^[[:space:]]+/, "", val)
+      sub(/[[:space:]]+$/, "", val)
+      gsub(/^"|"$/, "", val)
+      gsub(/^'\''|'\''$/, "", val)
+      print val
+      exit
+    }' "$config_path")"
+  fi
+
+  printf '%s' "$value"
+}
+
+check_nodejs_version() {
+  # Check if the DDEV container's Node.js version meets the minimum requirement.
+  # Sets NODEJS_VERSION_TOO_OLD=1 and NODEJS_DETECTED_VERSION if too old.
+  # Returns 0 if OK or not set (DDEV defaults to 20), 1 if too old.
+  local config_path="$1"
+  local node_ver
+  NODEJS_VERSION_TOO_OLD=0
+  NODEJS_DETECTED_VERSION=""
+  node_ver="$(detect_nodejs_version "$config_path")"
+
+  if [ -z "$node_ver" ]; then
+    return 0
+  fi
+
+  # Extract major version (handle values like "16", "16.x", "16.20.2").
+  local major="${node_ver%%[.x-]*}"
+  if [ -z "$major" ] || ! [[ "$major" =~ ^[0-9]+$ ]]; then
+    return 0
+  fi
+
+  if [ "$major" -lt 18 ]; then
+    NODEJS_VERSION_TOO_OLD=1
+    NODEJS_DETECTED_VERSION="$node_ver"
+    return 1
+  fi
+
+  return 0
+}
+
+prompt_nodejs_version_action() {
+  # Prompt the user to abort, skip node tooling, or remove the add-on when
+  # the DDEV Node.js version is too old.
+  # Sets NODE_VERSION_ACTION to: abort, skip, or remove.
+  local node_ver="$1"
+  local non_interactive="$2"
+  NODE_VERSION_ACTION="skip"
+
+  emit '\n'
+  emit 'Node.js 18 or higher is required for the JS-based code quality tooling\n'
+  emit '(Stylelint, ESLint, Prettier). Your DDEV config sets nodejs_version: "%s".\n' "$node_ver"
+  emit '\n'
+  emit 'We recommend you fix this before continuing. You can:\n'
+  emit '\n'
+  emit '  [a]bort  — Exit the installer. Fix with:\n'
+  emit '             ddev config --nodejs-version 20 && ddev restart\n'
+  emit '             then re-run: ddev add-on get UltraBob/ddev-drupal-code-quality\n'
+  emit '             To fully remove the add-on instead:\n'
+  emit '             ddev add-on remove drupal-code-quality\n'
+  emit '\n'
+  emit '  [s]kip   — Continue without JS tooling (PHP tools still work)\n'
+  emit '\n'
+
+  if [ "$non_interactive" -eq 1 ]; then
+    emit 'Non-interactive mode: skipping JS toolchain install (Node.js too old).\n'
+    NODE_VERSION_ACTION="skip"
+    return
+  fi
+
+  if [ "${PROMPT_AVAILABLE:-0}" -ne 1 ]; then
+    emit 'No interactive terminal; skipping JS toolchain install.\n'
+    NODE_VERSION_ACTION="skip"
+    return
+  fi
+
+  printf '[a]bort or [s]kip? (default: skip) ' >&"$PROMPT_OUT_FD"
+  local answer=""
+  if ! IFS= read -r -u "$PROMPT_IN_FD" answer; then
+    answer=""
+  fi
+  answer="$(string_lower "$answer")"
+  answer="${answer//$'\r'/}"
+  answer="${answer//$'\n'/}"
+  answer="$(printf '%s' "$answer" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+
+  case "${answer:0:1}" in
+    a) NODE_VERSION_ACTION="abort" ;;
+    *) NODE_VERSION_ACTION="skip" ;;
+  esac
+}
+
+maybe_add_engines_node() {
+  # Offer to add engines.node to an existing package.json that lacks it.
+  # Skipped in non-interactive mode unless the field is missing and we just
+  # created the file (create_root_package_json already handles new files).
+  local app_root="$1"
+  local non_interactive="$2"
+  local pkg="${app_root%/}/package.json"
+
+  if [ ! -f "$pkg" ]; then
+    return 0
+  fi
+
+  # Check if engines.node is already present.
+  if grep -q '"engines"' "$pkg" 2>/dev/null; then
+    return 0
+  fi
+
+  if [ "$non_interactive" -eq 1 ]; then
+    emit 'Note: package.json has no "engines" field. Consider adding "engines": {"node": ">=20.0"} for compatibility.\n'
+    return 0
+  fi
+
+  if ! prompt_yes_no 'Your package.json has no "engines" field. Add "engines": {"node": ">=20.0"} for Node.js compatibility?' 0; then
+    return 0
+  fi
+
+  # Use PHP inside the container (same base64 pattern as create_root_package_json).
+  local ddev_cmd="${DDEV_EXECUTABLE:-ddev}"
+  local php_add_engines
+  php_add_engines=$(cat <<'PHPCODE'
+$path = "/var/www/html/package.json";
+$data = json_decode(file_get_contents($path), true);
+if (!is_array($data) || isset($data["engines"])) { exit(1); }
+$data["engines"] = ["node" => ">=20.0"];
+file_put_contents($path, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+PHPCODE
+  )
+  local php_payload
+  php_payload="$(printf '%s' "$php_add_engines" | base64 | tr -d '\n')"
+  if command_available "$ddev_cmd" && \
+     "$ddev_cmd" exec bash -lc "php -r 'eval(base64_decode(\"${php_payload}\"));'" >/dev/null 2>&1; then
+    # Sync the container file back to the host.
+    "$ddev_cmd" exec cat /var/www/html/package.json > "$pkg" 2>/dev/null || true
+    emit 'Added "engines": {"node": ">=20.0"} to package.json.\n'
+  else
+    emit 'Could not update package.json automatically. Add manually:\n'
+    emit '  "engines": {"node": ">=20.0"}\n'
+  fi
+}
+
 prompt_setup() {
   # Detect a usable TTY for prompts. Falls back to /dev/tty when stdin/stdout
   # are redirected (e.g., running from automation).
@@ -2156,6 +2307,24 @@ elif command_available "${DDEV_EXECUTABLE:-ddev}"; then
 fi
 
 if [ "$core_package_json_present" -eq 1 ]; then
+  # Check DDEV Node.js version before proceeding with JS toolchain setup.
+  ddev_config="${app_root%/}/.ddev/config.yaml"
+  if ! check_nodejs_version "$ddev_config"; then
+    prompt_nodejs_version_action "$NODEJS_DETECTED_VERSION" "$non_interactive"
+    case "$NODE_VERSION_ACTION" in
+      abort)
+        emit 'Aborting installer. Fix your Node.js version, then re-run the add-on install.\n'
+        exit 0
+        ;;
+      skip)
+        emit 'Skipping JS toolchain install (Node.js too old). PHP tooling is still available.\n'
+        core_package_json_present=0
+        ;;
+    esac
+  fi
+fi
+
+if [ "$core_package_json_present" -eq 1 ]; then
   node_mode_raw="$(string_lower "${DCQ_INSTALL_NODE_DEPS:-}")"
   node_toolchain_existing=0
   if node_toolchain_present "$app_root"; then
@@ -2321,6 +2490,11 @@ if [ "$core_package_json_present" -eq 1 ]; then
 
       if [ "$target" = "root" ]; then
         node_target_choice="$target"
+      fi
+
+      # Offer to add engines.node to existing package.json before installing.
+      if [ "$target" = "root" ] && [ "$has_root_package_json" -eq 1 ]; then
+        maybe_add_engines_node "$app_root" "$non_interactive"
       fi
 
       node_install_done=0

--- a/dcq-install.sh
+++ b/dcq-install.sh
@@ -1756,6 +1756,7 @@ case "$install_mode" in
 esac
 
 emit '\n==> Phase 1: PHP tooling dependencies\n'
+php_deps_failed=0
 vendor_bin="${app_root%/}/vendor/bin"
 missing_tools=()
 for tool in phpstan phpcs phpcbf; do
@@ -1830,14 +1831,66 @@ if [ "${#missing_tools[@]}" -gt 0 ]; then
     if [ "$should_install" -ne 1 ]; then
       emit "Skipping dependency install. Run '%s' later to enable PHPStan/PHPCS/PHPCBF.\n" "${cmd[*]}"
     else
-      (
-        cd "$app_root"
-        if [ "$recommended_mode" -eq 1 ]; then
-          ensure_composer_plugin_blocked "$ddev_cmd" "$app_root"
+      composer_succeeded=0
+      while true; do
+        if (
+          cd "$app_root"
+          if [ "$recommended_mode" -eq 1 ]; then
+            ensure_composer_plugin_blocked "$ddev_cmd" "$app_root"
+          fi
+          run_command "${cmd[@]}"
+        ); then
+          composer_succeeded=1
+          break
         fi
-        run_command "${cmd[@]}"
-      )
-      emit 'Dependencies installed.\n'
+
+        emit '\n'
+        emit 'WARNING: PHP dev tools installation failed.\n'
+        emit 'The composer output above should indicate the cause. Common issues:\n'
+        emit '  - Security advisories blocking dependency resolution (update Drupal core first)\n'
+        emit '  - allow-plugins not configured (add the plugin to composer.json allow-plugins)\n'
+        emit '\n'
+        emit 'You can fix the issue in another terminal and retry.\n'
+        emit 'Command was: %s\n' "${cmd[*]}"
+
+        if [ "$non_interactive" -eq 1 ]; then
+          emit 'Non-interactive mode: proceeding without PHP dev tools.\n'
+          break
+        fi
+
+        if [ "${PROMPT_AVAILABLE:-0}" -ne 1 ]; then
+          emit 'No interactive terminal: proceeding without PHP dev tools.\n'
+          break
+        fi
+
+        printf '\n[r]etry, [p]roceed without PHP tools, [a]bort install (default: proceed): ' >&"$PROMPT_OUT_FD"
+        fail_answer=""
+        if ! IFS= read -r -u "$PROMPT_IN_FD" fail_answer; then
+          fail_answer=""
+        fi
+        fail_answer="$(string_lower "$(printf '%s' "$fail_answer" | tr -d '\r\n')")"
+
+        case "$fail_answer" in
+          r|retry)
+            emit 'Retrying composer install...\n'
+            continue
+            ;;
+          a|abort)
+            emit 'Aborting install.\n'
+            exit 1
+            ;;
+          *)
+            emit 'Proceeding without PHP dev tools.\n'
+            break
+            ;;
+        esac
+      done
+
+      if [ "$composer_succeeded" -eq 1 ]; then
+        emit 'Dependencies installed.\n'
+      else
+        php_deps_failed=1
+      fi
     fi
   fi
 fi
@@ -2512,6 +2565,8 @@ print_install_summary() {
 
   if [ "$php_deps_status" = "installed" ]; then
     emit '  - PHP dev tools (PHPStan, PHPCS, etc.)\n'
+  elif [ "$php_deps_status" = "failed" ]; then
+    emit '  - PHP dev tools: FAILED (see warning below)\n'
   else
     emit '  - PHP dev tools: NOT installed\n'
   fi
@@ -2532,7 +2587,12 @@ print_install_summary() {
   emit 'Next steps:\n'
   local step_num=1
 
-  if [ "$php_deps_status" != "installed" ]; then
+  if [ "$php_deps_status" = "failed" ]; then
+    emit '  %s. FIX: PHP dev tools failed to install. Resolve the composer issue\n' "$step_num"
+    emit '     (see error output above), then run:\n'
+    emit '     ddev composer require --dev drupal/core-dev --with-all-dependencies\n'
+    step_num=$((step_num + 1))
+  elif [ "$php_deps_status" != "installed" ]; then
     emit '  %s. Install PHP tools: ddev composer require --dev drupal/core-dev\n' "$step_num"
     step_num=$((step_num + 1))
   fi
@@ -2593,7 +2653,9 @@ print_install_summary() {
 
 # Determine summary statuses
 php_deps_summary="skipped"
-if [ "${should_install:-0}" -eq 1 ]; then
+if [ "${php_deps_failed:-0}" -eq 1 ]; then
+  php_deps_summary="failed"
+elif [ "${should_install:-0}" -eq 1 ]; then
   php_deps_summary="installed"
 fi
 

--- a/dcq-install.sh
+++ b/dcq-install.sh
@@ -1599,11 +1599,7 @@ run_command() {
   # terminal query/response noise (OSC/DSR bytes) that can appear as garbage.
   local arg
   local status
-  emit 'Running:'
-  for arg in "$@"; do
-    emit ' %q' "$arg"
-  done
-  emit '\n'
+  emit 'Running: %s\n' "$*"
   if [ "${non_interactive:-0}" -eq 1 ] || [ "${PROMPT_AVAILABLE:-0}" -ne 1 ]; then
     "$@"
   else

--- a/drupal-code-quality/assets/.cspell.json
+++ b/drupal-code-quality/assets/.cspell.json
@@ -33,7 +33,9 @@
         "./gitlab_templates/CHANGELOG.md",
         "./gitlab_templates/docs/jobs/composer.md",
         "./gitlab_templates/assets/internal/composer.json",
-        "./composer.json"
+        "./composer.json",
+        "**/settings.ddev.php",
+        "**/playwright-report/**"
     ],
     "dictionaries": [
         "companies",

--- a/drupal-code-quality/assets/.cspell.json
+++ b/drupal-code-quality/assets/.cspell.json
@@ -8,6 +8,7 @@
     "ignorePaths": [
         "web/core",
         "web/*/contrib/**",
+        "web/themes/!(custom)/**",
         "web/libraries/!(custom)/**",
         "web/sites/*/files",
         "vendor",
@@ -35,7 +36,8 @@
         "./gitlab_templates/assets/internal/composer.json",
         "./composer.json",
         "**/settings.ddev.php",
-        "**/playwright-report/**"
+        "**/playwright-report/**",
+        "config/sync"
     ],
     "dictionaries": [
         "companies",

--- a/drupal-code-quality/assets/.eslintignore
+++ b/drupal-code-quality/assets/.eslintignore
@@ -9,3 +9,4 @@ vendor/**
 **/dist/**
 **/build/**
 **/sites/*/files/**
+**/playwright-report/**

--- a/drupal-code-quality/assets/.eslintignore
+++ b/drupal-code-quality/assets/.eslintignore
@@ -3,8 +3,8 @@
 # Keep custom code and site config in scope by excluding dependency/generated trees.
 **/core/**
 **/contrib/**
-**/themes/**
-!**/themes/custom/**
+**/themes/*/
+!**/themes/custom/
 **/libraries/**
 **/node_modules/**
 vendor/**

--- a/drupal-code-quality/assets/.eslintignore
+++ b/drupal-code-quality/assets/.eslintignore
@@ -6,4 +6,6 @@
 **/libraries/**
 **/node_modules/**
 vendor/**
+**/dist/**
+**/build/**
 **/sites/*/files/**

--- a/drupal-code-quality/assets/.eslintignore
+++ b/drupal-code-quality/assets/.eslintignore
@@ -3,6 +3,8 @@
 # Keep custom code and site config in scope by excluding dependency/generated trees.
 **/core/**
 **/contrib/**
+**/themes/**
+!**/themes/custom/**
 **/libraries/**
 **/node_modules/**
 vendor/**

--- a/drupal-code-quality/assets/.stylelintignore
+++ b/drupal-code-quality/assets/.stylelintignore
@@ -6,4 +6,8 @@
 **/libraries/**
 **/node_modules/**
 vendor/**
+**/dist/**
+**/build/**
 **/sites/*/files/**
+# Playwright report output contains minified CSS that causes false positives.
+# **/playwright-report/**

--- a/drupal-code-quality/assets/.stylelintignore
+++ b/drupal-code-quality/assets/.stylelintignore
@@ -3,8 +3,8 @@
 # Keep custom code and site config in scope by excluding dependency/generated trees.
 **/core/**
 **/contrib/**
-**/themes/**
-!**/themes/custom/**
+**/themes/*/
+!**/themes/custom/
 **/libraries/**
 **/node_modules/**
 vendor/**

--- a/drupal-code-quality/assets/.stylelintignore
+++ b/drupal-code-quality/assets/.stylelintignore
@@ -3,6 +3,8 @@
 # Keep custom code and site config in scope by excluding dependency/generated trees.
 **/core/**
 **/contrib/**
+**/themes/**
+!**/themes/custom/**
 **/libraries/**
 **/node_modules/**
 vendor/**

--- a/drupal-code-quality/assets/.stylelintignore
+++ b/drupal-code-quality/assets/.stylelintignore
@@ -10,4 +10,4 @@ vendor/**
 **/build/**
 **/sites/*/files/**
 # Playwright report output contains minified CSS that causes false positives.
-# **/playwright-report/**
+**/playwright-report/**

--- a/drupal-code-quality/assets/dcq-packages.json
+++ b/drupal-code-quality/assets/dcq-packages.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "Curated npm packages required by DCQ configs. Names only; versions resolve from core at install time. To update: review .eslintrc.json, .eslintrc.jquery.json, .stylelintrc.json for extends/plugins/peer-deps.",
+  "packages": [
+    "cspell",
+    "eslint",
+    "eslint-config-airbnb-base",
+    "eslint-config-prettier",
+    "eslint-plugin-import",
+    "eslint-plugin-jsdoc",
+    "eslint-plugin-no-jquery",
+    "eslint-plugin-prettier",
+    "eslint-plugin-yml",
+    "prettier",
+    "stylelint",
+    "stylelint-config-standard",
+    "stylelint-order",
+    "stylelint-prettier"
+  ]
+}

--- a/drupal-code-quality/config-amendments/.phpcs.dcq.xml
+++ b/drupal-code-quality/config-amendments/.phpcs.dcq.xml
@@ -4,10 +4,15 @@
 
   <rule ref="DrupalPractice"/>
 
-  <!-- Default to scanning the Drupal docroot when no path is provided. -->
-  <file>__DOCROOT__</file>
+  <!-- Scan custom code directories. Modules and profiles use the broad parent
+       directory so non-standard layouts (modules outside custom/) are not missed.
+       Themes use themes/custom/ specifically to exclude core/CMS themes like
+       blank/ that sit outside contrib/. -->
+  <file>__DOCROOT__/modules</file>
+  <file>__DOCROOT__/themes/custom</file>
+  <file>__DOCROOT__/profiles</file>
+  <file>__DOCROOT__/sites</file>
 
-  <exclude-pattern>__DOCROOT__/core/**</exclude-pattern>
   <exclude-pattern>**/contrib/**</exclude-pattern>
   <exclude-pattern>**/node_modules/**</exclude-pattern>
   <exclude-pattern>__DOCROOT__/sites/*/files/**</exclude-pattern>

--- a/drupal-code-quality/config-amendments/.phpcs.dcq.xml
+++ b/drupal-code-quality/config-amendments/.phpcs.dcq.xml
@@ -11,3 +11,4 @@
   <exclude-pattern>**/contrib/**</exclude-pattern>
   <exclude-pattern>**/node_modules/**</exclude-pattern>
   <exclude-pattern>__DOCROOT__/sites/*/files/**</exclude-pattern>
+  <exclude-pattern>__DOCROOT__/sites/*/settings.ddev.php</exclude-pattern>

--- a/drupal-code-quality/config-amendments/.prettierignore.dcq
+++ b/drupal-code-quality/config-amendments/.prettierignore.dcq
@@ -3,8 +3,8 @@
 # Keep custom code and site config in scope by excluding dependency/generated trees.
 **/core/**
 **/contrib/**
-**/themes/**
-!**/themes/custom/**
+**/themes/*/
+!**/themes/custom/
 **/libraries/**
 **/node_modules/**
 vendor/**

--- a/drupal-code-quality/config-amendments/.prettierignore.dcq
+++ b/drupal-code-quality/config-amendments/.prettierignore.dcq
@@ -3,6 +3,8 @@
 # Keep custom code and site config in scope by excluding dependency/generated trees.
 **/core/**
 **/contrib/**
+**/themes/**
+!**/themes/custom/**
 **/libraries/**
 **/node_modules/**
 vendor/**

--- a/drupal-code-quality/config-amendments/.prettierignore.dcq
+++ b/drupal-code-quality/config-amendments/.prettierignore.dcq
@@ -7,3 +7,4 @@
 **/node_modules/**
 vendor/**
 **/sites/*/files/**
+**/playwright-report/**

--- a/drupal-code-quality/config-amendments/.stylelintrc.dcq.json
+++ b/drupal-code-quality/config-amendments/.stylelintrc.dcq.json
@@ -1,0 +1,5 @@
+#ddev-generated
+{
+  "_comment": "DCQ amendments merged into .stylelintrc.json during installation.",
+  "allowEmptyInput": true
+}

--- a/drupal-code-quality/config-amendments/phpstan.dcq.neon
+++ b/drupal-code-quality/config-amendments/phpstan.dcq.neon
@@ -10,6 +10,8 @@ parameters:
     excludePaths:
         analyseAndScan:
             - __DOCROOT__/sites/*/files/*
+            - __DOCROOT__/sites/*/settings.ddev.php
+            - __DOCROOT__/sites/*/default.settings.php
 
 # Baseline guidance:
 # - Generate a baseline with: ddev phpstan --generate-baseline

--- a/drupal-code-quality/tooling/scripts/prepare-cspell.php
+++ b/drupal-code-quality/tooling/scripts/prepare-cspell.php
@@ -151,6 +151,9 @@ $cspell_json['words'] = array_values(array_filter(array_unique(array_merge(
   // Add the alternative suggestion for a flagged word that is not in the
   // pre-configured dictionaries.
   ['blocklisted'],
+  // Add words used in environment variable names.
+  // See https://git.drupalcode.org/project/gitlab_templates/-/issues/3572383
+  ['flagwords', 'mkdocs'],
 ))));
 $quiet ?: print '$cspell_json[\'words\']=' . print_r($cspell_json['words'], TRUE) . PHP_EOL;
 

--- a/install.yaml
+++ b/install.yaml
@@ -5,6 +5,7 @@ name: drupal-code-quality
 # Files copied into the project's .ddev directory.
 project_files:
   - commands/helpers/path-map.sh
+  - commands/helpers/node-toolchain.sh
   - commands/web/checks
   - commands/web/composer-validate
   - commands/web/cspell

--- a/install.yaml
+++ b/install.yaml
@@ -4,6 +4,7 @@ name: drupal-code-quality
 
 # Files copied into the project's .ddev directory.
 project_files:
+  - config.drupal-code-quality.yaml
   - commands/helpers/path-map.sh
   - commands/helpers/node-toolchain.sh
   - commands/web/checks

--- a/scripts/sync-upstream-configs.sh
+++ b/scripts/sync-upstream-configs.sh
@@ -254,6 +254,58 @@ for entry in "${MANIFEST[@]}"; do
   fi
 done
 
+# --- Package list drift check ---
+# Compare curated dcq-packages.json against core's package.json to detect:
+# - Curated packages that core dropped (we depend on something core no longer ships)
+# - New eslint/stylelint/prettier/cspell packages in core we might want to adopt
+printf "\n"
+printf "${BOLD}%-40s${RESET} " "dcq-packages.json vs core"
+total=$((total + 1))
+
+core_pkg_url="${base_url}/project/drupal/-/raw/${branch_core}/core/package.json"
+core_pkg_fetched="${tmp_dir}/core-package.json"
+http_code=$(curl --fail --silent --output "$core_pkg_fetched" --write-out '%{http_code}' "$core_pkg_url" 2>/dev/null || true)
+
+if [[ ! -f "$core_pkg_fetched" ]] || [[ ! -s "$core_pkg_fetched" ]] || [[ "$http_code" -ge 400 ]]; then
+  printf "${RED}FETCH FAILED (HTTP %s)${RESET}\n" "$http_code"
+  fetch_errors=$((fetch_errors + 1))
+else
+  drift_output=$(python3 -c "
+import json, sys
+core = json.load(open(sys.argv[1]))
+dcq = json.load(open(sys.argv[2]))
+core_deps = {**core.get('dependencies', {}), **core.get('devDependencies', {})}
+curated = set(dcq.get('packages', []))
+prefixes = ('eslint-', 'eslint', 'stylelint-', 'stylelint', 'prettier', 'cspell')
+
+missing = sorted(p for p in curated if p not in core_deps)
+new_linting = sorted(
+    p for p in core_deps
+    if p not in curated and any(p == x or p.startswith(x + '-') for x in prefixes)
+)
+
+if missing:
+    print('Curated packages MISSING from core:')
+    for p in missing:
+        print(f'  - {p}')
+if new_linting:
+    print('New linting packages in core (not in curated list):')
+    for p in new_linting:
+        print(f'  + {p}')
+if not missing and not new_linting:
+    sys.exit(0)
+sys.exit(1)
+" "$core_pkg_fetched" "${repo_root}/drupal-code-quality/assets/dcq-packages.json" 2>&1) && {
+    printf "${GREEN}up to date${RESET}\n"
+    up_to_date=$((up_to_date + 1))
+  } || {
+    printf "${RED}DRIFT DETECTED${RESET}\n"
+    echo "$drift_output"
+    echo
+    changed=$((changed + 1))
+  }
+fi
+
 # --- Summary ---
 echo
 printf "${BOLD}Summary:${RESET} %d checked, %d up to date, %d changed" "$total" "$up_to_date" "$changed"

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1031,7 +1031,7 @@ PY
   assert_success
 }
 
-@test "stylelint-fix rewrites explicit web paths with non-web docroot" {
+@test "stylelint-fix passes paths through with non-web docroot" {
   set -u -o pipefail
   mkdir -p docroot
   run ddev config --docroot=docroot
@@ -1045,7 +1045,7 @@ PY
   mkdir -p node_modules/stylelint/bin
   cat > node_modules/stylelint/bin/stylelint.mjs <<'JS'
 #!/usr/bin/env node
-process.exit(0);
+process.stdout.write(process.argv.slice(2).join("\n"));
 JS
   chmod +x node_modules/stylelint/bin/stylelint.mjs
 
@@ -1061,8 +1061,11 @@ CSS
   run wait_for_container_path "/var/www/html/docroot/themes/custom/dcq_theme/css/fixable.css"
   assert_success
 
-  run ddev stylelint-fix web/themes/custom/dcq_theme/css/fixable.css
+  # Wrapper passes paths through as-is; no docroot rewriting.
+  run ddev stylelint-fix docroot/themes/custom/dcq_theme/css/fixable.css
   assert_success
+  assert_output --partial "--fix"
+  assert_output --partial "docroot/themes/custom/dcq_theme/css/fixable.css"
 }
 
 @test "eslint fixed mode falls back to .eslintrc.json when passing config is missing" {
@@ -1123,52 +1126,16 @@ JS
   esac
 }
 
-@test "stylelint-fix fails with helpful message when project config is missing" {
+@test "stylelint-fix delegates config and ignore handling to native stylelint" {
   set -u -o pipefail
   export DCQ_INSTALL_DEPS=skip
   export DCQ_INSTALL_NODE_DEPS=skip
   run ddev add-on get "${DIR}"
   assert_success
 
+  # Remove root configs — wrapper should not care; native stylelint handles errors.
   run rm -f .stylelintrc.json .stylelintrc .stylelintrc.yaml .stylelintrc.yml .stylelintrc.js
   assert_success
-
-  mkdir -p node_modules/stylelint/bin
-  cat > node_modules/stylelint/bin/stylelint.mjs <<'JS'
-#!/usr/bin/env node
-process.exit(0);
-JS
-  chmod +x node_modules/stylelint/bin/stylelint.mjs
-
-  run wait_for_container_path "/var/www/html/node_modules/stylelint/bin/stylelint.mjs"
-  assert_success
-
-  run ddev stylelint-fix web/themes/custom/dcq_theme/css/fixable.css
-  assert_failure
-  assert_output --partial "Stylelint config file is missing."
-}
-
-@test "stylelint-fix uses nearest config when root config is missing" {
-  set -u -o pipefail
-  export DCQ_INSTALL_DEPS=skip
-  export DCQ_INSTALL_NODE_DEPS=skip
-  run ddev add-on get "${DIR}"
-  assert_success
-
-  run rm -f .stylelintrc.json .stylelintrc .stylelintrc.yaml .stylelintrc.yml .stylelintrc.js
-  assert_success
-
-  mkdir -p web/themes/custom/dcq_theme/css
-  cat > web/themes/custom/dcq_theme/.stylelintrc.json <<'JSON'
-{
-  "rules": {}
-}
-JSON
-  cat > web/themes/custom/dcq_theme/css/fixable.css <<'CSS'
-a {
-  color: RED;
-}
-CSS
 
   mkdir -p node_modules/stylelint/bin
   cat > node_modules/stylelint/bin/stylelint.mjs <<'JS'
@@ -1180,33 +1147,33 @@ JS
   run wait_for_container_path "/var/www/html/node_modules/stylelint/bin/stylelint.mjs"
   assert_success
 
+  # Wrapper no longer checks for config or injects flags — all native.
   run ddev stylelint-fix web/themes/custom/dcq_theme/css/fixable.css
   assert_success
-  assert_output --partial "--config"
-  assert_output --partial "/var/www/html/web/themes/custom/dcq_theme/.stylelintrc.json"
+  refute_output --partial "Stylelint config file is missing."
+  assert_output --partial "--fix"
+  refute_output --partial "--config"
+  refute_output --partial "--config-basedir"
+  refute_output --partial "--ignore-path"
 }
 
-@test "stylelint preserves --ignore-path with explicit paths when nearest config triggers CMD reassignment" {
+@test "stylelint trusts native ignore-file handling with explicit paths" {
   set -u -o pipefail
   export DCQ_INSTALL_DEPS=skip
   export DCQ_INSTALL_NODE_DEPS=skip
   run ddev add-on get "${DIR}"
   assert_success
 
-  # Root config triggers the first CMD reassignment.
   cat > .stylelintrc.json <<'JSON'
 {
   "rules": {}
 }
 JSON
 
-  # .stylelintignore is what we expect to survive the reassignments.
   cat > .stylelintignore <<'TXT'
 web/core/**
 TXT
 
-  # Nearest config inside the theme triggers the explicit-paths CMD reassignment
-  # that previously wiped --ignore-path.
   mkdir -p web/themes/custom/dcq_theme/css
   cat > web/themes/custom/dcq_theme/.stylelintrc.json <<'JSON'
 {
@@ -1229,13 +1196,17 @@ JS
   run wait_for_container_path "/var/www/html/node_modules/stylelint/bin/stylelint.mjs"
   assert_success
 
+  # Wrapper delegates .stylelintignore handling to native stylelint (CWD=PROJECT_ROOT).
+  # No --ignore-path injection — the CMD-reassignment bug (issue #27) is structurally impossible.
   run ddev stylelint web/themes/custom/dcq_theme/css/fixable.css
   assert_success
-  assert_output --partial "--ignore-path="
-  assert_output --partial "/var/www/html/.stylelintignore"
+  refute_output --partial "--ignore-path"
+  refute_output --partial "--config"
+  # Path translation still works.
+  assert_output --partial "web/themes/custom/dcq_theme/css/fixable.css"
 }
 
-@test "stylelint preserves --ignore-path in default-files mode when nearest config triggers CMD reassignment" {
+@test "stylelint trusts native ignore-file handling in default-glob mode" {
   set -u -o pipefail
   export DCQ_INSTALL_DEPS=skip
   export DCQ_INSTALL_NODE_DEPS=skip
@@ -1252,8 +1223,6 @@ JSON
 web/core/**
 TXT
 
-  # Nearest config inside the theme triggers the default-files-branch CMD
-  # reassignment that previously wiped --ignore-path.
   mkdir -p web/themes/custom/dcq_theme/css
   cat > web/themes/custom/dcq_theme/.stylelintrc.json <<'JSON'
 {
@@ -1276,11 +1245,47 @@ JS
   run wait_for_container_path "/var/www/html/node_modules/stylelint/bin/stylelint.mjs"
   assert_success
 
-  # No explicit paths -- exercises the default-files branch.
+  # No explicit paths — default glob injected. No --ignore-path injection;
+  # native stylelint picks up .stylelintignore from CWD (PROJECT_ROOT).
   run ddev stylelint
   assert_success
-  assert_output --partial "--ignore-path="
-  assert_output --partial "/var/www/html/.stylelintignore"
+  refute_output --partial "--ignore-path"
+  refute_output --partial "--config"
+  # Default glob is CSS-only.
+  assert_output --partial "**/*.css"
+}
+
+@test "stylelint emits SCSS hint when SCSS files are present" {
+  set -u -o pipefail
+  export DCQ_INSTALL_DEPS=skip
+  export DCQ_INSTALL_NODE_DEPS=skip
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  mkdir -p node_modules/stylelint/bin
+  cat > node_modules/stylelint/bin/stylelint.mjs <<'JS'
+#!/usr/bin/env node
+process.stdout.write(process.argv.slice(2).join("\n"));
+JS
+  chmod +x node_modules/stylelint/bin/stylelint.mjs
+
+  # Create an SCSS file outside node_modules/vendor.
+  mkdir -p web/themes/custom/dcq_theme/scss
+  cat > web/themes/custom/dcq_theme/scss/style.scss <<'SCSS'
+$primary: #333;
+a { color: $primary; }
+SCSS
+
+  run wait_for_container_path "/var/www/html/node_modules/stylelint/bin/stylelint.mjs"
+  assert_success
+  run wait_for_container_path "/var/www/html/web/themes/custom/dcq_theme/scss/style.scss"
+  assert_success
+
+  # Default invocation (no args) should emit SCSS hint to stderr.
+  run ddev stylelint
+  assert_success
+  assert_output --partial "SCSS/Sass files found but not included in the default scan"
+  assert_output --partial "stylelint-config-standard-scss"
 }
 
 @test "prettier-fix fails with helpful message when project config is missing" {
@@ -1918,12 +1923,8 @@ JSON
   assert_not_equal "$before_prettier" "$after_prettier"
   assert_file_exist "dcq-reports/_prettier.patch"
 
-  # Test stylelint-fix --preview shows prompt and patch
-  before_stylelint="$(read_container_file /var/www/html/web/themes/custom/dcq_theme/css/fixable.css)"
-  run_with_prompt_yes "Apply these changes? [y/N]" ./.ddev/drupal-code-quality/tooling/bin/stylelint-fix --preview web/themes/custom/dcq_theme/css/fixable.css
-  assert_success
-  assert_output --partial "Apply these changes? [y/N]"
-  after_stylelint="$(read_container_file /var/www/html/web/themes/custom/dcq_theme/css/fixable.css)"
-  assert_not_equal "$before_stylelint" "$after_stylelint"
-  assert_file_exist "dcq-reports/_stylelint.patch"
+  # Test stylelint-fix --preview exits with error (preview mode removed)
+  run ./.ddev/drupal-code-quality/tooling/bin/stylelint-fix --preview web/themes/custom/dcq_theme/css/fixable.css
+  assert_failure
+  assert_output --partial "--preview has been removed"
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1284,7 +1284,7 @@ SCSS
   # Default invocation (no args) should emit SCSS hint to stderr.
   run ddev stylelint
   assert_success
-  assert_output --partial "SCSS/Sass files found but not included in the default scan"
+  assert_output --partial "SCSS/Sass files detected but not included in the default scan"
   assert_output --partial "stylelint-config-standard-scss"
 }
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -744,9 +744,16 @@ teardown() {
 
 @test "install summary says already present when tools exist" {
   set -u -o pipefail
-  # First install to get tools in place.
+  # First install to get configs in place.
   run ddev add-on get "${DIR}"
   assert_success
+
+  # Create fake vendor/bin tools so the "already present" check succeeds.
+  mkdir -p vendor/bin
+  for tool in phpstan phpcs phpcbf; do
+    printf '#!/bin/sh\nexit 0\n' > "vendor/bin/$tool"
+    chmod +x "vendor/bin/$tool"
+  done
 
   # Re-install with skip mode — tools are already present.
   export DCQ_INSTALL_MODE=skip
@@ -763,7 +770,6 @@ teardown() {
   run ddev add-on get "${DIR}"
   assert_success
   refute_output --partial "Removed"
-  refute_output --partial "dcq-install.sh"
 }
 
 @test "installer prompt defaults to recommended settings" {
@@ -1104,9 +1110,9 @@ PY
   assert_failure
   run grep -n '<rule ref="DrupalPractice"/>' ".phpcs.xml"
   assert_success
-  run grep -n "<file>docroot</file>" ".phpcs.xml"
+  run grep -n "<file>docroot/modules</file>" ".phpcs.xml"
   assert_success
-  run grep -n "docroot/core/\\*\\*" ".phpcs.xml"
+  run grep -n "<file>docroot/themes/custom</file>" ".phpcs.xml"
   assert_success
   run grep -n "docroot/sites" ".phpcs.xml"
   assert_success

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1245,17 +1245,18 @@ JS
   run wait_for_container_path "/var/www/html/node_modules/stylelint/bin/stylelint.mjs"
   assert_success
 
-  # No explicit paths — default glob injected. No --ignore-path injection;
+  # No explicit paths — default globs injected. No --ignore-path injection;
   # native stylelint picks up .stylelintignore from CWD (PROJECT_ROOT).
   run ddev stylelint
   assert_success
   refute_output --partial "--ignore-path"
   refute_output --partial "--config"
-  # Default glob is CSS-only.
+  # Default globs include CSS, SCSS, and Sass.
   assert_output --partial "**/*.css"
+  assert_output --partial "**/*.scss"
 }
 
-@test "stylelint emits SCSS hint when SCSS files are present" {
+@test "stylelint default scan includes CSS and SCSS globs" {
   set -u -o pipefail
   export DCQ_INSTALL_DEPS=skip
   export DCQ_INSTALL_NODE_DEPS=skip
@@ -1269,23 +1270,15 @@ process.stdout.write(process.argv.slice(2).join("\n"));
 JS
   chmod +x node_modules/stylelint/bin/stylelint.mjs
 
-  # Create an SCSS file outside node_modules/vendor.
-  mkdir -p web/themes/custom/dcq_theme/scss
-  cat > web/themes/custom/dcq_theme/scss/style.scss <<'SCSS'
-$primary: #333;
-a { color: $primary; }
-SCSS
-
   run wait_for_container_path "/var/www/html/node_modules/stylelint/bin/stylelint.mjs"
   assert_success
-  run wait_for_container_path "/var/www/html/web/themes/custom/dcq_theme/scss/style.scss"
-  assert_success
 
-  # Default invocation (no args) should emit SCSS hint to stderr.
+  # Default invocation includes CSS, SCSS, and Sass globs.
   run ddev stylelint
   assert_success
-  assert_output --partial "SCSS/Sass files detected but not included in the default scan"
-  assert_output --partial "stylelint-config-standard-scss"
+  assert_output --partial "**/*.css"
+  assert_output --partial "**/*.scss"
+  assert_output --partial "**/*.sass"
 }
 
 @test "prettier-fix fails with helpful message when project config is missing" {

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -388,16 +388,7 @@ wait_for_container_path() {
 }
 
 ensure_node_toolchain() {
-  if ddev exec test -x /var/www/html/web/core/node_modules/.bin/cspell >/dev/null 2>&1; then
-    return 0
-  fi
   if ddev exec test -x /var/www/html/node_modules/.bin/cspell >/dev/null 2>&1; then
-    return 0
-  fi
-
-  if ddev exec test -f /var/www/html/web/core/package.json >/dev/null 2>&1; then
-    run ddev exec bash -lc "corepack enable && cd /var/www/html/web/core && yarn install"
-    assert_success
     return 0
   fi
 
@@ -1682,13 +1673,15 @@ JSON
   restart_or_start_ddev
   assert_addon_installed
   ensure_node_toolchain
-  run ddev exec bash -lc $'mkdir -p /var/www/html/web/core/node_modules/.bin\ncat > /var/www/html/web/core/node_modules/.bin/cspell <<\'SH\'\n#!/bin/sh\necho \"core cspell should not be used\" >&2\nexit 99\nSH\nchmod +x /var/www/html/web/core/node_modules/.bin/cspell\nmkdir -p /var/www/html/web/core/node_modules/stylelint/bin\ncat > /var/www/html/web/core/node_modules/stylelint/bin/stylelint.mjs <<\'JS\'\nconsole.error(\"core stylelint should not be used\");\nprocess.exit(99);\nJS\ncat > /var/www/html/web/core/node_modules/.bin/prettier <<\'SH\'\n#!/bin/sh\necho \"core prettier should not be used\" >&2\nexit 99\nSH\nchmod +x /var/www/html/web/core/node_modules/.bin/prettier'
+  run ddev exec bash -lc $'mkdir -p /var/www/html/web/core/node_modules/.bin\ncat > /var/www/html/web/core/node_modules/.bin/cspell <<\'SH\'\n#!/bin/sh\necho \"core cspell should not be used\" >&2\nexit 99\nSH\nchmod +x /var/www/html/web/core/node_modules/.bin/cspell\nmkdir -p /var/www/html/web/core/node_modules/stylelint/bin\ncat > /var/www/html/web/core/node_modules/stylelint/bin/stylelint.mjs <<\'JS\'\nconsole.error(\"core stylelint should not be used\");\nprocess.exit(99);\nJS\ncat > /var/www/html/web/core/node_modules/.bin/prettier <<\'SH\'\n#!/bin/sh\necho \"core prettier should not be used\" >&2\nexit 99\nSH\nchmod +x /var/www/html/web/core/node_modules/.bin/prettier\nmkdir -p /var/www/html/web/core/node_modules/eslint/bin\ncat > /var/www/html/web/core/node_modules/eslint/bin/eslint.js <<\'JS\'\nconsole.error(\"core eslint should not be used\");\nprocess.exit(99);\nJS'
   assert_success
   run ./.ddev/drupal-code-quality/tooling/bin/cspell --version
   assert_success
   run ./.ddev/drupal-code-quality/tooling/bin/stylelint --version
   assert_success
   run ./.ddev/drupal-code-quality/tooling/bin/prettier --version
+  assert_success
+  run ./.ddev/drupal-code-quality/tooling/bin/eslint --version
   assert_success
   assert_file_exist ".vscode/settings.json"
   assert_file_exist ".vscode/extensions.json"

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -269,8 +269,23 @@ write_stub_package_json() {
 {
   "name": "dcq-test",
   "private": true,
+  "engines": {
+    "node": ">= 20.0"
+  },
   "devDependencies": {
+    "cspell": "^9.2.2",
+    "eslint": "^8.57.1",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-import": "^2.32.0",
+    "eslint-plugin-jsdoc": "^61.2.1",
     "eslint-plugin-no-jquery": "^3.1.1",
+    "eslint-plugin-prettier": "^5.5.4",
+    "eslint-plugin-yml": "^1.19.0",
+    "prettier": "^3.6.2",
+    "stylelint": "^16.25.0",
+    "stylelint-config-standard": "^38.0.0",
+    "stylelint-order": "^7.0.0",
     "stylelint-prettier": "^5.0.3"
   }
 }
@@ -686,6 +701,66 @@ teardown() {
   fi
   assert_success
   health_checks
+}
+
+@test "install excludes DDEV-generated files and sets allowEmptyInput" {
+  set -u -o pipefail
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  # F10: dcq-packages.json should NOT be in the project root.
+  run test -f dcq-packages.json
+  assert_failure
+
+  # F3: allowEmptyInput should be merged into .stylelintrc.json.
+  run grep -q '"allowEmptyInput"' .stylelintrc.json
+  assert_success
+
+  # F4: settings.ddev.php should be excluded from PHPCS.
+  run grep 'settings\.ddev\.php' .phpcs.xml
+  assert_success
+
+  # F4: settings.ddev.php and default.settings.php should be excluded from PHPStan.
+  run grep 'settings\.ddev\.php' phpstan.neon
+  assert_success
+  run grep 'default\.settings\.php' phpstan.neon
+  assert_success
+
+  # F4: settings.ddev.php should be excluded from CSpell.
+  run grep 'settings\.ddev\.php' .cspell.json
+  assert_success
+
+  # Playwright-report should be excluded from eslint, stylelint, prettier ignore files.
+  run grep 'playwright-report' .eslintignore
+  assert_success
+  run grep 'playwright-report' .stylelintignore
+  assert_success
+  run grep 'playwright-report' .prettierignore
+  assert_success
+}
+
+@test "install summary says already present when tools exist" {
+  set -u -o pipefail
+  # First install to get tools in place.
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  # Re-install with skip mode — tools are already present.
+  export DCQ_INSTALL_MODE=skip
+  run ddev add-on get "${DIR}"
+  assert_success
+  assert_output --partial "PHP dev tools already present"
+  assert_output --partial "already present (skipped)"
+  # Should NOT suggest installing tools that are already present.
+  refute_output --partial "Install PHP tools:"
+}
+
+@test "install does not emit dcq-install.sh removal message" {
+  set -u -o pipefail
+  run ddev add-on get "${DIR}"
+  assert_success
+  refute_output --partial "Removed"
+  refute_output --partial "dcq-install.sh"
 }
 
 @test "installer prompt defaults to recommended settings" {
@@ -1927,7 +2002,19 @@ JSON
   "name": "dcq-fail-test",
   "private": true,
   "devDependencies": {
+    "cspell": "^9.2.2",
+    "eslint": "^8.57.1",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-import": "^2.32.0",
+    "eslint-plugin-jsdoc": "^61.2.1",
     "eslint-plugin-no-jquery": "^3.1.1",
+    "eslint-plugin-prettier": "^5.5.4",
+    "eslint-plugin-yml": "^1.19.0",
+    "prettier": "^3.6.2",
+    "stylelint": "^16.25.0",
+    "stylelint-config-standard": "^38.0.0",
+    "stylelint-order": "^7.0.0",
     "stylelint-prettier": "^5.0.3",
     "this-package-should-not-exist-dcq-test": "99999.0.0"
   }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -769,6 +769,15 @@ PY
   # Ensure PHP dependency prompt path is exercised.
   write_minimal_composer_json "composer.json"
 
+  # Add SCSS files so the SCSS detection path is exercised.
+  # Node install is declined in this test, so the SCSS prompt won't appear
+  # (it requires node_mode != skip), but summary guidance should.
+  mkdir -p web/themes/custom/dcq_theme/src/sass
+  cat > web/themes/custom/dcq_theme/src/sass/style.scss <<'SCSS'
+$color: red;
+body { color: $color; }
+SCSS
+
   python_bin=""
   if command -v python3 >/dev/null 2>&1; then
     python_bin="python3"
@@ -836,6 +845,10 @@ PY
   assert_output --partial "Skipping IDE settings/extensions install."
   assert_output --partial "Add 'dcq-reports/' to .gitignore? [Y/n]"
   assert_output --partial "Set phpstan.neon level"
+  # SCSS files exist but Node was skipped — summary should show guidance.
+  # Assert before helpers that use `run` (which overwrites $output).
+  assert_output --partial "SCSS files were detected but SCSS support was not configured"
+  assert_output --partial "stylelint-config-standard-scss"
   # PHPStan level should be 0 (not the recommended 3) since user chose it
   assert_phpstan_level "0"
   assert_file_not_exist ".vscode/settings.json"
@@ -1251,12 +1264,13 @@ JS
   assert_success
   refute_output --partial "--ignore-path"
   refute_output --partial "--config"
-  # Default globs include CSS, SCSS, and Sass.
+  # Default glob is CSS-only (safe default matching shipped config).
   assert_output --partial "**/*.css"
-  assert_output --partial "**/*.scss"
+  refute_output --partial "**/*.scss"
+  refute_output --partial "**/*.sass"
 }
 
-@test "stylelint default scan includes CSS and SCSS globs" {
+@test "stylelint default scan is CSS-only" {
   set -u -o pipefail
   export DCQ_INSTALL_DEPS=skip
   export DCQ_INSTALL_NODE_DEPS=skip
@@ -1273,12 +1287,201 @@ JS
   run wait_for_container_path "/var/www/html/node_modules/stylelint/bin/stylelint.mjs"
   assert_success
 
-  # Default invocation includes CSS, SCSS, and Sass globs.
+  # Default invocation includes only CSS globs — SCSS/Sass require opt-in
+  # via DCQ_STYLELINT_GLOBS because the shipped config is CSS-only.
+  run ddev stylelint
+  assert_success
+  assert_output --partial "**/*.css"
+  refute_output --partial "**/*.scss"
+  refute_output --partial "**/*.sass"
+}
+
+@test "DCQ_STYLELINT_GLOBS overrides default stylelint scan globs" {
+  set -u -o pipefail
+  export DCQ_INSTALL_DEPS=skip
+  export DCQ_INSTALL_NODE_DEPS=skip
+
+  # Set custom globs via web_environment in a separate config file
+  # (the real user workflow — DDEV merges config.*.yaml automatically).
+  cat > .ddev/config.dcq-test.yaml <<'YAML'
+web_environment:
+  - "DCQ_STYLELINT_GLOBS=**/*.css **/*.scss"
+YAML
+
+  run ddev add-on get "${DIR}"
+  assert_success
+  # web_environment requires a restart to propagate to the container.
+  run ddev restart
+  assert_success
+
+  mkdir -p node_modules/stylelint/bin
+  cat > node_modules/stylelint/bin/stylelint.mjs <<'JS'
+#!/usr/bin/env node
+process.stdout.write(process.argv.slice(2).join("\n"));
+JS
+  chmod +x node_modules/stylelint/bin/stylelint.mjs
+
+  run wait_for_container_path "/var/www/html/node_modules/stylelint/bin/stylelint.mjs"
+  assert_success
+
+  # Custom globs from DCQ_STYLELINT_GLOBS replace the default.
   run ddev stylelint
   assert_success
   assert_output --partial "**/*.css"
   assert_output --partial "**/*.scss"
-  assert_output --partial "**/*.sass"
+  # Sass was not in the custom globs.
+  refute_output --partial "**/*.sass"
+}
+
+@test "DCQ_STYLELINT_GLOBS overrides stylelint-fix default globs too" {
+  set -u -o pipefail
+  export DCQ_INSTALL_DEPS=skip
+  export DCQ_INSTALL_NODE_DEPS=skip
+
+  cat > .ddev/config.dcq-test.yaml <<'YAML'
+web_environment:
+  - "DCQ_STYLELINT_GLOBS=**/*.vue **/*.svelte"
+YAML
+
+  run ddev add-on get "${DIR}"
+  assert_success
+  # web_environment requires a restart to propagate to the container.
+  run ddev restart
+  assert_success
+
+  mkdir -p node_modules/stylelint/bin
+  cat > node_modules/stylelint/bin/stylelint.mjs <<'JS'
+#!/usr/bin/env node
+process.stdout.write(process.argv.slice(2).join("\n"));
+JS
+  chmod +x node_modules/stylelint/bin/stylelint.mjs
+
+  run wait_for_container_path "/var/www/html/node_modules/stylelint/bin/stylelint.mjs"
+  assert_success
+
+  # stylelint-fix should also respect the env var with non-default globs.
+  run ddev stylelint-fix
+  assert_success
+  assert_output --partial "--fix"
+  assert_output --partial "**/*.vue"
+  assert_output --partial "**/*.svelte"
+  # Default globs should NOT appear when overridden.
+  refute_output --partial "**/*.css"
+}
+
+@test "installer prints SCSS guidance when scss files detected and using defaults" {
+  set -u -o pipefail
+  export DCQ_INSTALL_DEPS=skip
+  export DCQ_INSTALL_NODE_DEPS=skip
+
+  # Create SCSS files that the installer should detect.
+  mkdir -p web/themes/custom/dcq_theme/src/sass
+  cat > web/themes/custom/dcq_theme/src/sass/style.scss <<'SCSS'
+$color: red;
+body { color: $color; }
+SCSS
+
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  # Non-interactive install with SCSS files should print guidance,
+  # not silently configure SCSS support.
+  assert_output --partial "SCSS"
+  assert_output --partial "stylelint-config-standard-scss"
+  assert_output --partial "DCQ_STYLELINT_GLOBS"
+}
+
+@test "installer creates config.drupal-code-quality.yaml with commented defaults" {
+  set -u -o pipefail
+  export DCQ_INSTALL_DEPS=skip
+  export DCQ_INSTALL_NODE_DEPS=skip
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  # The add-on config file should exist with documented defaults.
+  assert_file_exist ".ddev/config.drupal-code-quality.yaml"
+  run cat .ddev/config.drupal-code-quality.yaml
+  assert_output --partial "DCQ_STYLELINT_GLOBS"
+}
+
+@test "installer detects fully configured SCSS support" {
+  set -u -o pipefail
+  export DCQ_INSTALL_DEPS=skip
+  export DCQ_INSTALL_NODE_DEPS=skip
+  # Use skip mode so the user's .stylelintrc.json is preserved.
+  export DCQ_INSTALL_MODE=skip
+
+  # Create SCSS files.
+  mkdir -p web/themes/custom/dcq_theme/src/sass
+  cat > web/themes/custom/dcq_theme/src/sass/style.scss <<'SCSS'
+$color: red;
+SCSS
+
+  # Both conditions: stylelintrc references scss AND DDEV config has scss globs.
+  cat > .stylelintrc.json <<'JSON'
+{
+  "extends": ["stylelint-config-standard-scss"]
+}
+JSON
+  cat > .ddev/config.drupal-code-quality.yaml <<'YAML'
+# Drupal Code Quality add-on configuration.
+web_environment:
+  - "DCQ_STYLELINT_GLOBS=**/*.css **/*.scss"
+YAML
+
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  # Should detect SCSS is already configured, not print setup guidance.
+  refute_output --partial "SCSS files were detected but"
+  refute_output --partial "To enable SCSS linting"
+}
+
+@test "installer detects partial SCSS config as not configured" {
+  set -u -o pipefail
+  export DCQ_INSTALL_DEPS=skip
+  export DCQ_INSTALL_NODE_DEPS=skip
+  # Use skip mode so the user's .stylelintrc.json is preserved.
+  export DCQ_INSTALL_MODE=skip
+
+  # Create SCSS files.
+  mkdir -p web/themes/custom/dcq_theme/src/sass
+  cat > web/themes/custom/dcq_theme/src/sass/style.scss <<'SCSS'
+$color: red;
+SCSS
+
+  # Only the stylelintrc — missing DDEV globs config.
+  cat > .stylelintrc.json <<'JSON'
+{
+  "extends": ["stylelint-config-standard-scss"]
+}
+JSON
+
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  # Partial config should still show guidance.
+  assert_output --partial "SCSS"
+  assert_output --partial "DCQ_STYLELINT_GLOBS"
+}
+
+@test "installer does not print SCSS guidance when no scss files exist" {
+  set -u -o pipefail
+  export DCQ_INSTALL_DEPS=skip
+  export DCQ_INSTALL_NODE_DEPS=skip
+
+  # No SCSS files in the project — only CSS.
+  mkdir -p web/themes/custom/dcq_theme/css
+  cat > web/themes/custom/dcq_theme/css/style.css <<'CSS'
+a { color: red; }
+CSS
+
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  # No SCSS guidance should appear.
+  refute_output --partial "stylelint-config-standard-scss"
+  refute_output --partial "DCQ_STYLELINT_GLOBS"
 }
 
 @test "prettier-fix fails with helpful message when project config is missing" {

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -391,12 +391,15 @@ wait_for_container_path() {
   local path="$1"
   local attempts=0
 
-  while [ "$attempts" -lt 5 ]; do
-    if ddev exec test -r "$path" >/dev/null 2>&1; then
+  # Flush Mutagen sync to ensure content (not just inodes) is present.
+  ddev mutagen sync >/dev/null 2>&1 || true
+
+  while [ "$attempts" -lt 10 ]; do
+    if ddev exec test -s "$path" >/dev/null 2>&1; then
       return 0
     fi
     attempts=$((attempts + 1))
-    sleep 1
+    sleep 2
   done
   echo "Timed out waiting for $path to sync into the container."
   return 1

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1728,6 +1728,100 @@ SH
   assert_success
 }
 
+@test "stylelint rejects Node.js older than 18" {
+  set -u -o pipefail
+  export DCQ_INSTALL_DEPS=skip
+  export DCQ_INSTALL_NODE_DEPS=skip
+  run ddev add-on get "${DIR}"
+  assert_success
+
+  # Write test scripts to the project root (writable, syncs to container).
+  cat > dcq-node-check-fail.sh <<'SH'
+#!/usr/bin/env bash
+set -u
+NODE_MAJOR=16
+if [ "${NODE_MAJOR:-0}" -lt 18 ]; then
+  echo "Error: Node.js $NODE_MAJOR is too old. Stylelint requires Node.js 18 or later." >&2
+  exit 1
+fi
+SH
+  cat > dcq-node-check-pass.sh <<'SH'
+#!/usr/bin/env bash
+set -u
+NODE_MAJOR=$(node -e 'console.log(process.versions.node.split(".")[0])')
+if [ "${NODE_MAJOR:-0}" -lt 18 ]; then
+  echo "Error: Node.js $NODE_MAJOR is too old." >&2
+  exit 1
+fi
+echo "Node $NODE_MAJOR OK"
+SH
+  chmod +x dcq-node-check-fail.sh dcq-node-check-pass.sh
+
+  run wait_for_container_path "/var/www/html/dcq-node-check-fail.sh"
+  assert_success
+
+  # Simulated Node 16 should trigger the guard.
+  run ddev exec bash /var/www/html/dcq-node-check-fail.sh
+  assert_failure
+  assert_output --partial "too old"
+  assert_output --partial "Node.js 18 or later"
+
+  # Real container Node version should pass.
+  run ddev exec bash /var/www/html/dcq-node-check-pass.sh
+  assert_success
+  assert_output --partial "OK"
+}
+
+@test "installer prompts abort/skip when DDEV nodejs_version is below 18" {
+  set -u -o pipefail
+  export DCQ_INSTALL_DEPS=skip
+
+  # Add nodejs_version: "16" to the main DDEV config (check_nodejs_version
+  # reads .ddev/config.yaml directly via awk, not the DDEV merge files).
+  echo 'nodejs_version: "16"' >> .ddev/config.yaml
+
+  # Phase 3 only fires when core package.json is present on the host.
+  local docroot="${DCQ_TEST_DOCROOT:-web}"
+  mkdir -p "${docroot}/core"
+  echo '{"name": "drupal/core", "devDependencies": {}}' > "${docroot}/core/package.json"
+
+  # Non-interactive mode defaults to skip.
+  run ddev add-on get "${DIR}"
+  assert_success
+  assert_output --partial "Node.js 18 or higher is required"
+  assert_output --partial 'nodejs_version: "16"'
+  assert_output --partial "ddev config --nodejs-version 20"
+  assert_output --partial "Skipping JS toolchain install (Node.js too old)"
+  # PHP tooling message should still appear
+  assert_output --partial "PHP tooling is still available"
+}
+
+@test "installer offers engines.node for package.json without engines" {
+  set -u -o pipefail
+  export DCQ_INSTALL_DEPS=skip
+  # Must be root/install so Phase 3 reaches the maybe_add_engines_node call.
+  export DCQ_INSTALL_NODE_DEPS=root
+
+  # Create a minimal package.json without engines.
+  cat > package.json <<'JSON'
+{
+  "name": "dcq-test-project",
+  "private": true
+}
+JSON
+
+  # Phase 3 needs core package.json to activate.
+  local docroot="${DCQ_TEST_DOCROOT:-web}"
+  mkdir -p "${docroot}/core"
+  echo '{"name": "drupal/core", "devDependencies": {}}' > "${docroot}/core/package.json"
+
+  run ddev add-on get "${DIR}"
+  # Install may fail during npm install (no real deps), but should still
+  # reach the engines check before that.
+  assert_output --partial "engines"
+  assert_output --partial ">=20.0"
+}
+
 @test "remove cleans ddev assets and shims" {
   set -u -o pipefail
   run ddev add-on get "${DIR}"


### PR DESCRIPTION
## Summary

- Install Node tooling at the project root instead of web/core, with curated DCQ package list
- Installer UX improvements from comprehensive UX audit
- Default scan scope fixes to reduce false positives on fresh installs

## Changes

### Scan scope and config defaults
- Scope all tools to scan only `themes/custom/` (not other themes like `blank/`)
- Exclude `settings.ddev.php` from PHPCS, PHPStan, and CSpell
- Exclude `default.settings.php` from PHPStan
- Exclude `config/sync` from CSpell (UUIDs and hash tokens)
- Exclude `playwright-report/` from all linters
- Add `allowEmptyInput` to stylelint via `.stylelintrc.dcq.json` config amendment
- Use compact formatter for stylelint in `ddev checks` to prevent RangeError crash on large projects
- Fix stylelint wrapper argument parser to handle `--formatter` and other value-taking flags
- Apply upstream CSpell word list changes (flagwords, mkdocs)

### Installer improvements
- Summary reports actual tool state ("already present (skipped)") instead of misleading "NOT installed"
- Phase 1 says "PHP dev tools already present" when tools exist
- Suppress "Removed dcq-install.sh" implementation detail
- SCSS setup steps use letters (a-d) to distinguish from numbered next-steps
- Add "this may take several minutes" to npm install message
- Use `ddev npm`/`ddev yarn` wrappers instead of `ddev exec` in commands
- Remove unnecessary `dcq-packages.json` from project root (internal manifest)

### Other
- SCSS detection and guided setup during install
- Composer failure handling with retry/proceed/abort prompt
- Node.js version check to prevent stylelint crashes on old Node
- IDE settings merge fix for Python exit codes
- Curated DCQ package list with upstream drift detection

## Closes

- Closes #30 — config/sync CSpell false positives and blank theme PHPCS noise
- Closes #28 — upstream config changes in prepare-cspell.php
- Closes #27 — stylelint now runs from project root with native .stylelintignore auto-discovery

## Test plan

- [ ] Fresh Drupal 11 install: `ddev checks` should show mostly clean (only phpstan settings.php and prettier README.md)
- [ ] Re-install on existing project: summary says "already present (skipped)"
- [ ] Large project (511_org): stylelint doesn't crash in `ddev checks` (compact formatter)
- [ ] Project with non-custom themes: themes outside `themes/custom/` are not scanned
- [ ] Drupal CMS: `config/sync` not scanned by CSpell
- [ ] Bats tests: `bats tests/test.bats --filter-tags '!release'`