### PR TITLE
use the ddev env variable to retrieve the projects docroot

### DIFF
--- a/dcq-install.sh
+++ b/dcq-install.sh
@@ -31,30 +31,6 @@ truthy() {
   return 1
 }
 
-detect_docroot() {
-  local config_path="$1"
-  local value=""
-
-  if [ -f "$config_path" ]; then
-    value="$(awk -F: '/^[[:space:]]*docroot:/ {
-      val=$2
-      sub(/^[[:space:]]+/, "", val)
-      sub(/[[:space:]]+$/, "", val)
-      gsub(/^"|"$/, "", val)
-      gsub(/^'\''|'\''$/, "", val)
-      print val
-      exit
-    }' "$config_path")"
-  fi
-
-  value="${value#/}"
-  value="${value%/}"
-  if [ -z "$value" ]; then
-    value="web"
-  fi
-  printf '%s' "$value"
-}
-
 detect_nodejs_version() {
   # Read the nodejs_version value from .ddev/config.yaml.
   # Returns the version string (e.g. "16", "20") or empty if not set.
@@ -1932,7 +1908,7 @@ if [ -z "$app_root" ]; then
   app_root="$(cd "$cwd/.." && pwd)"
 fi
 
-dcq_docroot="$(detect_docroot "${app_root%/}/.ddev/config.yaml")"
+dcq_docroot="${DDEV_DOCROOT}"
 DCQ_DOCROOT="$dcq_docroot"
 DOCROOT_CONTAINER="/var/www/html/${DCQ_DOCROOT}"
 DOCROOT_COREDIR="${DOCROOT_CONTAINER}/core"

--- a/dcq-install.sh
+++ b/dcq-install.sh
@@ -1908,7 +1908,7 @@ if [ -z "$app_root" ]; then
   app_root="$(cd "$cwd/.." && pwd)"
 fi
 
-dcq_docroot="${DDEV_DOCROOT}"
+dcq_docroot="${DDEV_DOCROOT-web}"
 DCQ_DOCROOT="$dcq_docroot"
 DOCROOT_CONTAINER="/var/www/html/${DCQ_DOCROOT}"
 DOCROOT_COREDIR="${DOCROOT_CONTAINER}/core"


### PR DESCRIPTION
## The Issue

- Fixes one aspect of #34 

<!-- Provide a brief description of the issue. -->

the manual detection in `detect_docroot()` had the shortcoming that an empty string within the docroot variable in the ddev config yaml was considered different to `.` - the docroot is not getting properly set. that way node dependencies are not getting installed in step 3 if the project has the project root as the docroot. 

## How This PR Solves The Issue
ddev provides a set of env variables https://docs.ddev.com/en/stable/users/extend/custom-commands/#environment-variables-provided . `DDEV_DOCROOT` which is one of those, contains the docroot set for the project at hand. that way it is possible to drop `detect_docroot()` and simply set `dcq_docroot="${DDEV_DOCROOT}"`


<!-- Describe the key change(s) in this PR that address the issue above. -->

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/UltraBob/ddev-drupal-code-quality/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
