### PR TITLE
Fix maintenance checker failures and sync upstream config changes

### DIFF
--- a/.github/workflows/maintenance-check.yml
+++ b/.github/workflows/maintenance-check.yml
@@ -1,0 +1,101 @@
+name: maintenance-check
+
+# Runs the DDEV add-on update checker (repo hygiene: #ddev-generated markers,
+# README sections, install.yaml structure, ...). On PRs and pushes a failure
+# blocks normally, since it is caused by the change under review. On scheduled
+# runs a failure is reported by filing/updating a labeled issue instead of
+# reddening the tests badge - the checker script is hosted by DDEV and its
+# rules can change without any change in this repo.
+#
+# No paths-ignore here: the checker validates README.md and other docs, so
+# markdown-only changes must still run it.
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+  schedule:
+    - cron: '25 08 * * *'
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  maintenance-checker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run DDEV Add-on Update Checker
+        id: checker
+        run: |
+          set +e
+          output=$(curl -fsSL https://ddev.com/s/addon-update-checker.sh | bash 2>&1)
+          exit_code=$?
+          echo "$output"
+          {
+            echo "CHECKER_OUTPUT<<CHECKER_EOF"
+            echo "$output"
+            echo "CHECKER_EOF"
+          } >> "$GITHUB_ENV"
+          exit $exit_code
+
+      - name: Create or update issue on scheduled failure
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = 'DDEV add-on maintenance checker is failing';
+            const label = 'maintenance-checker';
+            const body = `The scheduled DDEV add-on update checker run failed.\n\n\`\`\`\n${process.env.CHECKER_OUTPUT}\n\`\`\`\n\nReproduce locally from the add-on root:\n\`\`\`\ncurl -fsSL https://ddev.com/s/addon-update-checker.sh | bash\n\`\`\``;
+
+            // Find existing open issue
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: label,
+            });
+
+            if (issues.data.length > 0) {
+              // Update existing issue
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issues.data[0].number,
+                body: body,
+              });
+              console.log(`Updated issue #${issues.data[0].number}`);
+            } else {
+              // Ensure label exists
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label,
+                });
+              } catch {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label,
+                  color: 'd93f0b',
+                  description: 'Automated DDEV add-on maintenance checker failures',
+                });
+              }
+
+              // Create new issue
+              const issue = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: title,
+                body: body,
+                labels: [label],
+              });
+              console.log(`Created issue #${issue.data.number}`);
+            }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,15 +32,7 @@ permissions:
   contents: read
 
 jobs:
-  maintenance-checker:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Run DDEV Add-on Update Checker
-        run: curl -fsSL https://ddev.com/s/addon-update-checker.sh | bash
-
   tests:
-    needs: maintenance-checker
     strategy:
       matrix:
         ddev_version: [stable, HEAD]

--- a/config.drupal-code-quality.yaml
+++ b/config.drupal-code-quality.yaml
@@ -1,3 +1,5 @@
+#ddev-generated
+# Remove the line above if you customize this file, so add-on updates don't overwrite it.
 # Drupal Code Quality add-on configuration.
 web_environment:
   # Default file patterns for ddev stylelint / ddev stylelint-fix (space-separated globs).

--- a/drupal-code-quality/assets/dcq-packages.json
+++ b/drupal-code-quality/assets/dcq-packages.json
@@ -1,6 +1,6 @@
 {
   "#ddev-generated": true,
-  "_comment": "Curated npm packages required by DCQ configs. Names only; versions resolve from core at install time. To update: review .eslintrc.json, .eslintrc.jquery.json, .stylelintrc.json for extends/plugins/peer-deps.",
+  "_comment": "Curated npm packages required by DCQ configs. Names only; versions resolve from core at install time. To update: review .eslintrc.json, .eslintrc.jquery.json, .stylelintrc.json for extends/plugins/peer-deps. Packages under 'excluded' exist in core's package.json but are deliberately not installed; the upstream drift check skips them.",
   "packages": [
     "cspell",
     "eslint",
@@ -16,5 +16,9 @@
     "stylelint-config-standard",
     "stylelint-order",
     "stylelint-prettier"
-  ]
+  ],
+  "excluded": {
+    "eslint-formatter-gitlab": "GitLab CI code-quality report serializer; no local CLI/IDE use",
+    "stylelint-checkstyle-formatter": "Checkstyle XML report serializer for CI; no local CLI/IDE use"
+  }
 }

--- a/drupal-code-quality/assets/dcq-packages.json
+++ b/drupal-code-quality/assets/dcq-packages.json
@@ -1,4 +1,5 @@
 {
+  "#ddev-generated": true,
   "_comment": "Curated npm packages required by DCQ configs. Names only; versions resolve from core at install time. To update: review .eslintrc.json, .eslintrc.jquery.json, .stylelintrc.json for extends/plugins/peer-deps.",
   "packages": [
     "cspell",

--- a/drupal-code-quality/tooling/scripts/prepare-cspell.php
+++ b/drupal-code-quality/tooling/scripts/prepare-cspell.php
@@ -153,7 +153,7 @@ $cspell_json['words'] = array_values(array_filter(array_unique(array_merge(
   ['blocklisted'],
   // Add words used in environment variable names.
   // See https://git.drupalcode.org/project/gitlab_templates/-/issues/3572383
-  ['flagwords', 'mkdocs'],
+  ['flagwords', 'mkdocs', 'autorun'],
 ))));
 $quiet ?: print '$cspell_json[\'words\']=' . print_r($cspell_json['words'], TRUE) . PHP_EOL;
 

--- a/scripts/sync-upstream-configs.sh
+++ b/scripts/sync-upstream-configs.sh
@@ -276,13 +276,20 @@ core = json.load(open(sys.argv[1]))
 dcq = json.load(open(sys.argv[2]))
 core_deps = {**core.get('dependencies', {}), **core.get('devDependencies', {})}
 curated = set(dcq.get('packages', []))
+excluded = set(dcq.get('excluded', {}))
 prefixes = ('eslint-', 'eslint', 'stylelint-', 'stylelint', 'prettier', 'cspell')
 
 missing = sorted(p for p in curated if p not in core_deps)
 new_linting = sorted(
     p for p in core_deps
-    if p not in curated and any(p == x or p.startswith(x + '-') for x in prefixes)
+    if p not in curated and p not in excluded
+    and any(p == x or p.startswith(x + '-') for x in prefixes)
 )
+stale_excluded = sorted(p for p in excluded if p not in core_deps)
+if stale_excluded:
+    print('Excluded packages no longer in core (can be removed from excluded list):')
+    for p in stale_excluded:
+        print(f'  - {p}')
 
 if missing:
     print('Curated packages MISSING from core:')
@@ -292,7 +299,7 @@ if new_linting:
     print('New linting packages in core (not in curated list):')
     for p in new_linting:
         print(f'  + {p}')
-if not missing and not new_linting:
+if not missing and not new_linting and not stale_excluded:
     sys.exit(0)
 sys.exit(1)
 " "$core_pkg_fetched" "${repo_root}/drupal-code-quality/assets/dcq-packages.json" 2>&1) && {

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1860,9 +1860,23 @@ SH
   set -u -o pipefail
   export DCQ_INSTALL_DEPS=skip
 
-  # Add nodejs_version: "16" to the main DDEV config (check_nodejs_version
+  # Set nodejs_version: "16" in the main DDEV config (check_nodejs_version
   # reads .ddev/config.yaml directly via awk, not the DDEV merge files).
-  echo 'nodejs_version: "16"' >> .ddev/config.yaml
+  # Replace the existing key rather than appending: ddev config already writes
+  # nodejs_version, and DDEV rejects config.yaml with duplicate mapping keys.
+  python3 - <<'PY'
+from pathlib import Path
+
+path = Path(".ddev/config.yaml")
+lines = path.read_text(encoding="utf-8").splitlines()
+for idx, line in enumerate(lines):
+    if line.strip().startswith("nodejs_version:"):
+        lines[idx] = 'nodejs_version: "16"'
+        break
+else:
+    lines.append('nodejs_version: "16"')
+path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+PY
 
   # Phase 3 only fires when core package.json is present on the host.
   local docroot="${DCQ_TEST_DOCROOT:-web}"


### PR DESCRIPTION
## Summary

- Add the `#ddev-generated` markers DDEV's addon-update-checker now requires in every file listed in `install.yaml` `project_files`, including files inside listed directories. `config.drupal-code-quality.yaml` gets the marker plus a note telling users to remove it when customizing; `dcq-packages.json` carries it as a JSON key that all consumers ignore. This fixes the scheduled maintenance-checker failures.
- Sync `prepare-cspell.php` with upstream gitlab_templates, which added `autorun` to the injected flagwords. Applied via `scripts/sync-upstream-configs.sh --update`; the DCQ `non_project_directories` patch is preserved.
- Record deliberately excluded core packages in `dcq-packages.json`. Drupal core added `eslint-formatter-gitlab` and `stylelint-checkstyle-formatter`, which serialize lint results into GitLab code-quality JSON and Checkstyle XML for CI pipelines and have no local CLI/IDE use. Instead of adopting them, an `excluded` map (package → reason) documents the decision and the drift check skips them. The check also flags excluded entries that disappear from core so the list can be pruned.
- Move the maintenance checker out of the tests workflow into its own `maintenance-check` workflow. It still blocks PRs and pushes to main, where a failure is caused by the change under review, but on scheduled runs it files or updates a labeled issue instead of turning the tests badge red. The checker is a hosted script whose rules can change without any change in this repo, as happened here.

Fixes #36

## Testing

- DDEV addon-update-checker passes locally
- `./scripts/sync-upstream-configs.sh` reports 10/10 checked files up to date with no package drift
- Full bats suite (`DCQ_FULL_TESTS=1`) passes locally; parallel runs on the local machine hit a pre-existing ddev-router recreate race unrelated to these changes, so part of the suite was validated serially