### PR TITLE
#38: Prettier ignore .inc files

### DIFF
--- a/drupal-code-quality/assets/.prettierignore
+++ b/drupal-code-quality/assets/.prettierignore
@@ -2,6 +2,3 @@
 # Default ignore list used by Drupal GitLab CI templates (include.drupalci.main.yml).
 # CI creates this file when missing; we vendor it here to keep local runs in parity.
 *.yml
-# Drupal .inc files are PHP, but prettier parses as HTML by default.
-# PHP files should be checked by phpcs/phpcbf instead.
-*.inc

--- a/drupal-code-quality/assets/.prettierignore
+++ b/drupal-code-quality/assets/.prettierignore
@@ -2,3 +2,6 @@
 # Default ignore list used by Drupal GitLab CI templates (include.drupalci.main.yml).
 # CI creates this file when missing; we vendor it here to keep local runs in parity.
 *.yml
+# Drupal .inc files are PHP, but prettier parses as HTML by default.
+# PHP files should be checked by phpcs/phpcbf instead.
+*.inc

--- a/drupal-code-quality/config-amendments/.prettierignore.dcq
+++ b/drupal-code-quality/config-amendments/.prettierignore.dcq
@@ -10,3 +10,7 @@
 vendor/**
 **/sites/*/files/**
 **/playwright-report/**
+
+# Drupal .inc files are PHP, but prettier infers the HTML parser from the
+# extension. PHP is covered by phpcs/phpcbf, which lists inc in its extensions.
+*.inc


### PR DESCRIPTION
## Narrow scope of prettier command

- Fixes #38 

ddev prettier command runs on .inc files, but shouldn't.

## How This PR Solves The Issue

Add .inc to .prettierignore.

## Manual Testing Instructions

Run ddev prettier on a directory that contains an .inc file.

```bash
ddev add-on get https://github.com/UltraBob/ddev-drupal-code-quality/tarball/refs/pull/39/head
ddev restart
```

## Automated Testing Overview

Probably not needed.

## Release/Deployment Notes

Unlikely to disrupt other usage.
