### PR TITLE
Document that VS Code recommended extensions require manual install

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,13 @@ manually.
 The template points PHP tooling at `.ddev/drupal-code-quality/tooling/bin` and JS tooling at local
 `node_modules`. Override the paths if you prefer a different location.
 
+Note that VS Code does not install the recommended extensions automatically.
+The first time you open the workspace after install, VS Code shows a
+notification that this workspace has extension recommendations — click
+**Show Recommendations** and install the listed extensions so the IDE
+integration works. If you dismissed the notification, open the Extensions view
+and filter by `@recommended` to find them.
+
 ## Requirements
 
 - DDEV project with Drupal core in the configured docroot (default `web/`).

--- a/dcq-install.sh
+++ b/dcq-install.sh
@@ -2865,6 +2865,11 @@ if [ -f "$ide_settings_template" ] || [ -f "$ide_extensions_template" ]; then
         printf 'WRITE: %s\n' "$ide_target_extensions"
       fi
     fi
+
+    emit 'NOTE: VS Code does not install recommended extensions automatically.\n'
+    emit '      When it shows the workspace recommendations notification, click\n'
+    emit '      "Show Recommendations" and install them (or open the Extensions\n'
+    emit '      view and filter by @recommended).\n'
   fi
 fi
 
@@ -2952,6 +2957,10 @@ print_install_summary() {
 
   if [ "$ide_status" = "skip" ]; then
     emit '  %s. Setup VS Code: see .ddev/drupal-code-quality/ide-settings/vscode/README.md\n' "$step_num"
+  else
+    emit '  %s. Install the recommended VS Code extensions when prompted\n' "$step_num"
+    emit '     (Extensions view, filter by @recommended); they are not installed\n'
+    emit '     automatically.\n'
   fi
 
   local scss_install_cmd

--- a/drupal-code-quality/ide-settings/vscode/README.md
+++ b/drupal-code-quality/ide-settings/vscode/README.md
@@ -14,6 +14,11 @@ installed by this add-on.
 
 ## Recommended extensions
 
+VS Code does not install recommended extensions automatically. When it shows
+the "this workspace has extension recommendations" notification, click
+**Show Recommendations** and install them. If the notification was dismissed,
+open the Extensions view and filter by `@recommended`.
+
 See `extensions.json` for the extension IDs. JS-focused extensions (ESLint,
 Stylelint, Prettier, CSpell) use local `node_modules` paths. The installer uses
 the Node toolchain choice (prompt or `DCQ_INSTALL_NODE_DEPS`) to configure those


### PR DESCRIPTION
Fixes #16

VS Code surfaces the add-on's `.vscode/extensions.json` recommendations only as a dismissible notification and never installs extensions automatically. As @rpkoller noted, the popup reads more like an advertisement than a required setup step, so users who dismiss it end up without the IDE integration working.

## Changes

- **README.md** — note at the end of the "IDE settings (VS Code/Codium)" section (just before Requirements, as suggested in the issue): click **Show Recommendations** on the notification, or filter the Extensions view by `@recommended` if it was dismissed.
- **drupal-code-quality/ide-settings/vscode/README.md** — same guidance at the top of the "Recommended extensions" section, since the installer points here for skip/manual setup.
- **dcq-install.sh** — a `NOTE:` emitted right after settings/extensions are written in Phase 4, and a "Next steps" entry in the install summary when IDE settings were installed. The skip branch keeps its existing pointer to the manual-setup doc.

## Testing

- `bash -n dcq-install.sh`
- `bats tests/test.bats --filter "VS Code settings merge handles JSONC"` (exercises the non-skip Phase 4 path including the new note)
- `bats tests/test.bats --filter "install summary says already present when tools exist"` (exercises the updated summary)

Thanks @rpkoller for the report and the placement suggestion.