### PR TITLE
Locate ddev robustly when shims run with a minimal GUI PATH

### DIFF
--- a/drupal-code-quality/tooling/bin/ddev-run
+++ b/drupal-code-quality/tooling/bin/ddev-run
@@ -18,6 +18,31 @@ fi
 
 cd "$repo_root"
 
+# IDEs launched from the Dock/Spotlight (macOS launchd) or a desktop session
+# (Linux systemd) inherit a minimal PATH that omits Homebrew and other common
+# install dirs, so ddev cannot be assumed resolvable. PATH lookup stays the
+# happy path; otherwise probe known install locations for the ddev binary.
+# DCQ_DDEV_DIRS is a test hook (colon-separated), not a supported setting.
+if ! command -v ddev >/dev/null 2>&1; then
+  if [ -n "${DCQ_DDEV_DIRS:-}" ]; then
+    IFS=':' read -r -a candidates <<< "$DCQ_DDEV_DIRS"
+  else
+    candidates=(/opt/homebrew/bin /usr/local/bin "${HOME:-}/.ddev/bin" /opt/ddev/bin)
+  fi
+  for candidate in "${candidates[@]}"; do
+    if [ -n "$candidate" ] && [ -x "$candidate/ddev" ]; then
+      PATH="$candidate:$PATH"
+      break
+    fi
+  done
+fi
+
+if ! command -v ddev >/dev/null 2>&1; then
+  echo "ddev-run: cannot locate the 'ddev' binary on PATH or in common install dirs." >&2
+  echo "Add ddev's directory to your IDE's PATH, or install ddev to a standard location." >&2
+  exit 127
+fi
+
 # The wrapper passes its own path as $1 so we can derive the tool name.
 tool_name="${1:-$0}"
 if [ "$tool_name" != "$0" ]; then

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1091,6 +1091,50 @@ PY
   assert_output "/var/www/html/web/index.php"
 }
 
+@test "ddev-run locates ddev when invoked with a minimal GUI PATH" {
+  set -u -o pipefail
+  run ddev add-on get "${DIR}"
+  assert_success
+  assert_file_exist ".ddev/drupal-code-quality/tooling/bin/ddev-run"
+
+  # Sandbox PATH holding only the utilities ddev-run itself needs — no ddev.
+  # This mimics the minimal launchd/systemd PATH that GUI-launched IDEs get.
+  sandbox_bin="${TESTDIR}/sandbox-bin"
+  mkdir -p "$sandbox_bin"
+  for util in bash dirname basename; do
+    ln -s "$(command -v "$util")" "$sandbox_bin/$util"
+  done
+
+  # Stub ddev in a fake install dir standing in for e.g. /opt/homebrew/bin.
+  candidate_bin="${TESTDIR}/fake-install-bin"
+  mkdir -p "$candidate_bin"
+  printf '#!/usr/bin/env bash\necho "candidate-ddev $*"\n' > "${candidate_bin}/ddev"
+  chmod +x "${candidate_bin}/ddev"
+
+  # Minimal PATH: the shim falls back to probing the candidate dirs.
+  run env PATH="$sandbox_bin" DCQ_DDEV_DIRS="${TESTDIR}/no-such-dir:${candidate_bin}" \
+    "${TESTDIR}/.ddev/drupal-code-quality/tooling/bin/phpstan" --version
+  assert_success
+  assert_output --partial "candidate-ddev phpstan --version"
+
+  # ddev already on PATH: unchanged behavior, candidates are not probed.
+  path_bin="${TESTDIR}/path-bin"
+  mkdir -p "$path_bin"
+  printf '#!/usr/bin/env bash\necho "path-ddev $*"\n' > "${path_bin}/ddev"
+  chmod +x "${path_bin}/ddev"
+  run env PATH="${path_bin}:${sandbox_bin}" DCQ_DDEV_DIRS="$candidate_bin" \
+    "${TESTDIR}/.ddev/drupal-code-quality/tooling/bin/phpstan" --version
+  assert_success
+  assert_output --partial "path-ddev phpstan --version"
+
+  # No ddev anywhere: exit 127 with actionable guidance.
+  run env PATH="$sandbox_bin" DCQ_DDEV_DIRS="${TESTDIR}/no-such-dir" \
+    "${TESTDIR}/.ddev/drupal-code-quality/tooling/bin/phpstan" --version
+  assert_failure
+  [ "$status" -eq 127 ]
+  assert_output --partial "cannot locate the 'ddev' binary"
+}
+
 @test "install from directory with non-web docroot" {
   set -u -o pipefail
   mkdir -p docroot


### PR DESCRIPTION
## Summary

IDEs launched from the Dock/Spotlight (macOS launchd) or a desktop session (Linux systemd) inherit a minimal `PATH` that omits Homebrew and other common install dirs, so every shim-backed IDE integration died with `exec: ddev: not found` — exactly the use case the shims exist for. Terminal use was unaffected because interactive shells put ddev on `PATH`.

`ddev-run` now resolves `ddev` once, before all delegation branches:

- Normal `PATH` lookup remains the happy path — no behavior change when `ddev` is already resolvable.
- On failure it probes known install locations (`/opt/homebrew/bin`, `/usr/local/bin`, `$HOME/.ddev/bin`, `/opt/ddev/bin`) and prepends the first match to `PATH`.
- If `ddev` still cannot be found, it exits 127 with a two-line stderr message telling the user to add ddev's directory to their IDE's `PATH` or install ddev to a standard location.

`$HOME` is guarded for `set -u`, the `#ddev-generated` header and project-root discovery are preserved, and all constructs are bash 3.2-compatible (`/usr/bin/env bash` resolves to stock macOS bash under the minimal GUI `PATH` this targets). `DCQ_DDEV_DIRS` is an internal colon-separated test hook for the candidate list, commented as unsupported — needed because the production candidates are absolute system paths a test cannot stub.

## Testing

New bats test "ddev-run locates ddev when invoked with a minimal GUI PATH" covers the acceptance criteria:

- Minimal `PATH` + stubbed `ddev` in a fake candidate dir → shim invocation succeeds via probing.
- `ddev` on `PATH` → unchanged behavior, candidates are not probed.
- No `ddev` anywhere → exit 127 with the guidance message.

The test sandboxes `PATH` to just the utilities `ddev-run` needs (`bash`, `dirname`, `basename`), so it exercises the fallback deterministically even on CI hosts where ddev lives in `/usr/bin`. The existing "install from directory" test still passes.

Fixes #40