### PR TITLE
Broaden PHPStan and PHPCS scan scope to cover non-standard custom code layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,13 +196,33 @@ and filter by `@recommended` to find them.
     single source of truth for Prettier scope.
 - PHPCS / PHPCBF default scope:
   - When a project `.phpcs.xml` is installed by the add-on, `ddev phpcs` and
-    `ddev phpcbf` with no path default to scanning the configured docroot.
-  - The generated ruleset excludes `__DOCROOT__/core/**`, `**/contrib/**`,
-    `**/node_modules/**`, and `__DOCROOT__/sites/*/files/**`.
+    `ddev phpcbf` with no path default to scanning `modules`, `themes`,
+    `profiles`, and `sites` under the docroot (the same scope as PHPStan).
+  - The generated ruleset excludes `**/contrib/**`, `**/node_modules/**`,
+    `__DOCROOT__/themes/blank/**` (the starter theme Drupal CMS site
+    templates generate directly under `themes/`), and
+    `__DOCROOT__/sites/*/files/**`.
   - You can still pass explicit paths to narrow runs.
 - PHP parallel lint scope:
   - `ddev php-parallel-lint` remains wrapper-scoped because the tool does not
     provide an equivalent project config file for default target paths.
+- PHPStan default scope:
+  - The installed `phpstan.neon` analyses `modules`, `themes`, `profiles`, and
+    `sites` under the docroot, excluding `contrib` subtrees and
+    `themes/blank` (the starter theme Drupal CMS site templates generate
+    directly under `themes/`). The broad parent directories are deliberate:
+    projects that keep custom code outside `modules/custom` (for example
+    `modules/common/`) are still analysed instead of being silently skipped.
+  - Contrib is excluded with `analyseAndScan`, so calls into contrib code
+    still type-check (phpstan-drupal resolves contrib classes on demand via
+    Drupal's autoloader) without scanning the contrib tree.
+  - This intentionally deviates from the GitLab CI template `paths` values:
+    the templates target contrib repos where the project root is the module
+    under test, while this add-on targets site projects whose custom code is
+    the target. Template parity applies to the rules, not the scan scope.
+  - First adoption on an existing project may surface previously-unseen
+    findings. Run `ddev phpstan --generate-baseline` once to capture existing
+    debt so only new regressions fail (see PHPStan baseline below).
 - PHPStan baseline:
   - Generate a baseline with `ddev phpstan --generate-baseline`.
   - This writes `phpstan-baseline.neon` at the project root and updates

--- a/dcq-install.sh
+++ b/dcq-install.sh
@@ -1306,10 +1306,14 @@ ensure_phpstan_paths() {
   local app_root="$1"
   local docroot="${DCQ_DOCROOT:-web}"
 
-  # Create standard Drupal directories that PHPStan config expects
+  # Create standard Drupal directories that the PHPStan and PHPCS configs
+  # expect: both error on nonexistent scan entries (modules, themes, profiles,
+  # sites). modules/custom and themes/custom are created via their parents as
+  # conventional layout hints.
   local paths=(
     "${docroot}/modules/custom"
     "${docroot}/themes/custom"
+    "${docroot}/profiles"
     "${docroot}/sites"
   )
 

--- a/drupal-code-quality/config-amendments/.phpcs.dcq.xml
+++ b/drupal-code-quality/config-amendments/.phpcs.dcq.xml
@@ -4,16 +4,18 @@
 
   <rule ref="DrupalPractice"/>
 
-  <!-- Scan custom code directories. Modules and profiles use the broad parent
-       directory so non-standard layouts (modules outside custom/) are not missed.
-       Themes use themes/custom/ specifically to exclude core/CMS themes like
-       blank/ that sit outside contrib/. -->
+  <!-- Scan custom code directories. All four use the broad parent directory
+       so non-standard layouts (modules outside custom/) are not missed.
+       contrib/ subtrees are excluded below, as is themes/blank/: Drupal CMS
+       site templates generate a starter theme directly under themes/ (named
+       blank in the official base template). -->
   <file>__DOCROOT__/modules</file>
-  <file>__DOCROOT__/themes/custom</file>
+  <file>__DOCROOT__/themes</file>
   <file>__DOCROOT__/profiles</file>
   <file>__DOCROOT__/sites</file>
 
   <exclude-pattern>**/contrib/**</exclude-pattern>
+  <exclude-pattern>__DOCROOT__/themes/blank/**</exclude-pattern>
   <exclude-pattern>**/node_modules/**</exclude-pattern>
   <exclude-pattern>__DOCROOT__/sites/*/files/**</exclude-pattern>
   <exclude-pattern>__DOCROOT__/sites/*/settings.ddev.php</exclude-pattern>

--- a/drupal-code-quality/config-amendments/phpstan.dcq.neon
+++ b/drupal-code-quality/config-amendments/phpstan.dcq.neon
@@ -2,13 +2,29 @@
 # DCQ defaults for local development
 # This file contains scope and exclusion paths that will be merged into phpstan.neon
 # during installation. The __DOCROOT__ placeholder is replaced with the actual docroot.
+# Note: only content below the parameters: line survives the merge, so keep
+# user-facing comments inside the parameters block.
 parameters:
+    # Scan the broad parent directories (not just */custom) so custom code in
+    # non-standard layouts (e.g. modules/common/) is analysed instead of being
+    # silently skipped. Contrib is excluded with analyseAndScan (not analyse):
+    # phpstan-drupal resolves contrib classes on demand via Drupal's
+    # autoloader, so calls into contrib still type-check without scanning the
+    # contrib tree. The trailing /* is deliberate — excludePaths uses fnmatch
+    # where * crosses /, so the exclusion is recursive.
     paths:
-        - __DOCROOT__/modules/custom
-        - __DOCROOT__/themes/custom
+        - __DOCROOT__/modules
+        - __DOCROOT__/themes
+        - __DOCROOT__/profiles
         - __DOCROOT__/sites
     excludePaths:
         analyseAndScan:
+            - __DOCROOT__/modules/contrib/*
+            - __DOCROOT__/themes/contrib/*
+            # Drupal CMS site templates generate a starter theme directly
+            # under themes/ (named blank in the official base template).
+            - __DOCROOT__/themes/blank/*
+            - __DOCROOT__/profiles/contrib/*
             - __DOCROOT__/sites/*/files/*
             - __DOCROOT__/sites/*/settings.ddev.php
             - __DOCROOT__/sites/*/default.settings.php

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -618,6 +618,52 @@ JS
 a { color: RED; }
 CSS
 
+  # Non-standard layout fixture: custom code outside modules/custom that
+  # PHPStan must still analyse (broad scan scope, issue #41).
+  local common_dir="web/modules/common/dcq_common"
+  mkdir -p "${common_dir}"
+  cat > "${common_dir}/dcq_common.info.yml" <<'YAML'
+name: DCQ Common
+type: module
+description: 'Fixture module outside modules/custom.'
+core_version_requirement: ^11
+package: Testing
+YAML
+  cat > "${common_dir}/dcq_common.module" <<'PHP'
+<?php
+
+/**
+ * @file
+ * Fixture module kept outside modules/custom.
+ */
+
+function dcq_common_fixture() {
+  if ($undefined_common_var) {
+    return $undefined_common_var;
+  }
+  return NULL;
+}
+PHP
+
+  # Drupal CMS generated-theme fixture: site templates generate a starter
+  # theme directly under themes/ (blank in the official base template); bad
+  # code here should NOT be flagged by PHPStan or PHPCS.
+  local blank_dir="web/themes/blank"
+  mkdir -p "${blank_dir}"
+  cat > "${blank_dir}/blank.info.yml" <<'YAML'
+name: Blank
+type: theme
+description: 'A completely blank theme.'
+core_version_requirement: ^11
+YAML
+  cat > "${blank_dir}/blank.theme" <<'PHP'
+<?php
+function blank_bad($x){
+  // TODO: This should NOT be flagged — generated CMS starter theme.
+  if($undefined_blank_var){return $undefined_blank_var;}
+}
+PHP
+
   # Clean fixture: valid custom code that should pass all checks.
   local clean_dir="web/modules/custom/dcq_clean"
   mkdir -p "${clean_dir}"
@@ -1112,7 +1158,9 @@ PY
   assert_success
   run grep -n "<file>docroot/modules</file>" ".phpcs.xml"
   assert_success
-  run grep -n "<file>docroot/themes/custom</file>" ".phpcs.xml"
+  run grep -n "<file>docroot/themes</file>" ".phpcs.xml"
+  assert_success
+  run grep -n "docroot/themes/blank" ".phpcs.xml"
   assert_success
   run grep -n "docroot/sites" ".phpcs.xml"
   assert_success
@@ -1120,9 +1168,19 @@ PY
   assert_failure
 
   # Verify PHPStan config uses custom docroot
-  run grep -q "docroot/modules/custom" phpstan.neon
+  run grep -q -- "- docroot/modules$" phpstan.neon
   assert_success
-  run grep -q "docroot/sites" phpstan.neon
+  run grep -q -- "- docroot/profiles$" phpstan.neon
+  assert_success
+  run grep -q "docroot/modules/contrib/\*" phpstan.neon
+  assert_success
+  run grep -q "docroot/themes/contrib/\*" phpstan.neon
+  assert_success
+  run grep -q "docroot/profiles/contrib/\*" phpstan.neon
+  assert_success
+  run grep -q "docroot/themes/blank/\*" phpstan.neon
+  assert_success
+  run grep -q -- "- docroot/sites$" phpstan.neon
   assert_success
   run grep -q "docroot/sites/\*/files/\*" phpstan.neon
   assert_success
@@ -1635,19 +1693,37 @@ JS
   run grep -q "paths:" phpstan.neon
   assert_success
 
-  # Check for expected default paths
-  run grep -q "web/modules/custom" phpstan.neon
+  # Check for expected default paths (broad parents, anchored so the
+  # contrib exclude entries below don't satisfy these greps).
+  run grep -q -- "- web/modules$" phpstan.neon
   assert_success
-  run grep -q "web/themes/custom" phpstan.neon
+  run grep -q -- "- web/themes$" phpstan.neon
   assert_success
-  run grep -q "web/sites" phpstan.neon
+  run grep -q -- "- web/profiles$" phpstan.neon
+  assert_success
+  run grep -q -- "- web/sites$" phpstan.neon
   assert_success
 
   # Check for excludePaths
   run grep -q "excludePaths:" phpstan.neon
   assert_success
+  run grep -q "web/modules/contrib/\*" phpstan.neon
+  assert_success
+  run grep -q "web/themes/contrib/\*" phpstan.neon
+  assert_success
+  run grep -q "web/themes/blank/\*" phpstan.neon
+  assert_success
+  run grep -q "web/profiles/contrib/\*" phpstan.neon
+  assert_success
   run grep -q "web/sites/\*/files/\*" phpstan.neon
   assert_success
+
+  # PHPStan errors on nonexistent paths entries, so the installer must
+  # pre-create every scanned directory even on projects that lack them.
+  for dir in web/modules web/themes web/profiles web/sites; do
+    run test -d "$dir"
+    assert_success
+  done
 }
 
 @test "phpstan excludes nested files directory descendants" {
@@ -2210,6 +2286,10 @@ JSON
   assert_success
   run wait_for_container_path "/var/www/html/web/modules/contrib/dcq_fake/dcq_fake.module"
   assert_success
+  run wait_for_container_path "/var/www/html/web/modules/common/dcq_common/dcq_common.module"
+  assert_success
+  run wait_for_container_path "/var/www/html/web/themes/blank/blank.theme"
+  assert_success
   run wait_for_container_path "/var/www/html/web/modules/custom/dcq_clean/dcq_clean.module"
   assert_success
 
@@ -2246,6 +2326,14 @@ JSON
   run ./.ddev/drupal-code-quality/tooling/bin/phpstan web/modules/custom/dcq_test/dcq_test.module
   assert_failure
   assert_output --partial "undefined"
+
+  # PHPStan default run covers custom code outside modules/custom (broad
+  # scan scope) while excluding contrib and the generated CMS starter theme.
+  run ./.ddev/drupal-code-quality/tooling/bin/phpstan
+  assert_failure
+  assert_output --partial "dcq_common.module"
+  refute_output --partial "dcq_fake.module"
+  refute_output --partial "blank.theme"
 
   # ESLint detects rule violations in check mode
   run ./.ddev/drupal-code-quality/tooling/bin/eslint web/themes/custom/dcq_theme/js/fixable.js
@@ -2290,10 +2378,12 @@ JSON
   # Detection accuracy: exclusion paths (contrib not flagged)
   # -----------------------------------------------------------
 
-  # PHPCS default run should NOT include contrib fixtures
+  # PHPCS default run should NOT include contrib fixtures or the generated
+  # CMS starter theme.
   run ./.ddev/drupal-code-quality/tooling/bin/phpcs
   assert_failure
   refute_output --partial "dcq_fake.module"
+  refute_output --partial "blank.theme"
 
   # ESLint default run should NOT include contrib fixtures
   run ./.ddev/drupal-code-quality/tooling/bin/eslint


### PR DESCRIPTION
Closes #41.

## Problem

The installed `phpstan.neon` limited analysis to `modules/custom`, `themes/custom`, and `sites` under the docroot. Projects keeping custom code elsewhere (e.g. `modules/common/`) got zero PHPStan coverage, silently — the installer even pre-created an empty `modules/custom`, so PHPStan exited green while analysing nothing.

## Changes

- **PHPStan scope** (`phpstan.dcq.neon`): scans the broad parents `modules`, `themes`, `profiles`, `sites` with recursive contrib exclusions under `excludePaths.analyseAndScan` (calls into contrib still type-check via phpstan-drupal's on-demand autoloader resolution; the trailing `/*` is recursive since PHPStan's fnmatch crosses `/`).
- **PHPCS aligned** (`.phpcs.dcq.xml`): `<file>` entries broadened from `themes/custom` to `themes`, with matching exclusions, so both tools share one scan philosophy.
- **`themes/blank` excluded from both**: Drupal CMS site templates generate a starter theme directly under `themes/` (named `blank` in the official base template) via `drupal/site_template_helper`, bypassing the composer installer-paths that route selectable themes (Haven, Byte, Mercury, Gin, …) to `themes/contrib/`. Verified against a real Drupal CMS project.
- **Installer**: pre-creates `profiles/` since PHPStan errors on nonexistent `paths` entries. `themes/custom`/`modules/custom` remain as conventional layout hints.
- **README**: documents the scope rationale (GitLab CI template parity applies to the rules, not the scan scope) and the first-adoption `ddev phpstan --generate-baseline` workflow for surfacing pre-existing debt without failing on it.

## Tests

- New full-install fixtures prove a default `ddev phpstan` run flags an undefined-variable error in `web/modules/common/` while reporting nothing from `modules/contrib/` or `themes/blank/`; same contrib/blank refutations for the default `ddev phpcs` run.
- Config-level assertions (anchored greps) for the new paths and exclusions in both the default-docroot and non-web-docroot install tests, plus an assertion that all four scanned parents are pre-created on bare projects.
- All targeted quick tests and two `DCQ_FULL_TESTS=1` full-install runs pass locally.

## Adoption note

Broadened scope will surface previously-unseen findings on existing projects; the README now recommends generating a baseline once on first adoption so only new regressions fail.