### PR TITLE
Tell reviewers to approve the held workflow runs, not reopen the PR

### DIFF
--- a/.github/workflows/upstream-config-check.yml
+++ b/.github/workflows/upstream-config-check.yml
@@ -177,12 +177,13 @@ jobs:
           The upstream config check found drift and applied it to the vendored assets on this branch.
 
           > [!IMPORTANT]
-          > **Close this pull request and reopen it before reviewing.**
+          > **Press "Approve and run workflows" below before reviewing.**
           >
-          > It was opened by `GITHUB_TOKEN`, and GitHub does not emit `pull_request`
-          > events for token-authored pull requests, so the required checks
-          > (`maintenance-checker`, `tests (stable)`, `tests (HEAD)`) never start.
-          > Reopening it counts as a human action and starts all three normally.
+          > This pull request was opened by `GITHUB_TOKEN`, so its `pull_request`
+          > runs are created but held in an `action_required` state rather than
+          > starting on their own. Approving them starts `maintenance-checker`,
+          > `tests (stable)` and `tests (HEAD)`. Closing and reopening the pull
+          > request also works, but approving is one click.
           MD
             # Warn whenever anything at all needs a human, not just patch
             # conflicts: curated package drift, a missing local file, a fetch


### PR DESCRIPTION
Corrects a factual claim in the generated pull request body, found by running the automation for real in #52.

## What the body claimed

> GitHub does not emit `pull_request` events for token-authored pull requests, so the required checks never start. Reopening it counts as a human action and starts all three normally.

## What actually happens

The first generated pull request (#52) created both runs, held rather than absent:

```
maintenance-check  event=pull_request  completed/action_required
tests              event=pull_request  completed/action_required
```

`action_required` means the run exists and is waiting for a maintainer to press **Approve and run workflows** — the same gate first-time contributor pull requests get. So there *is* something to approve, and it is one click rather than a close plus a reopen.

Closing and reopening still works, so it stays in the text as the alternative.

## Note

Seven rounds of review across correctness, security and maintainability did not catch this, and could not have. Every reviewer confirmed the claim was internally consistent — the condition matched the comment, the comment matched the body — but the premise itself was an untested assertion about GitHub's behaviour. It took one real run to falsify.

Body text only; no logic changes. `actionlint` clean.