### PR TITLE
Exclude node_modules from the PHPStan scan paths

### DIFF
--- a/drupal-code-quality/config-amendments/phpstan.dcq.neon
+++ b/drupal-code-quality/config-amendments/phpstan.dcq.neon
@@ -25,6 +25,9 @@ parameters:
             # under themes/ (named blank in the official base template).
             - __DOCROOT__/themes/blank/*
             - __DOCROOT__/profiles/contrib/*
+            # npm packages vendored under custom themes/modules ship PHP
+            # helpers (e.g. flatted) that are not project code.
+            - __DOCROOT__/*/node_modules/*
             - __DOCROOT__/sites/*/files/*
             - __DOCROOT__/sites/*/settings.ddev.php
             - __DOCROOT__/sites/*/default.settings.php


### PR DESCRIPTION
## Summary

Excludes npm packages vendored under custom themes and modules from PHPStan analysis. The change is in the config amendment that gets merged into the project's phpstan.neon at install time, not in the stock asset.

Some npm packages ship PHP files (flatted, pulled in by flat-cache via eslint, ships a php/ port). Those are not project code and produce findings the project cannot act on.

## Test plan

- Install the add-on on a project whose custom theme has node_modules containing a PHP file
- Run `ddev phpstan`
- Confirm the vendored PHP file is not analysed

Fixes #68

Drafted with AI assistance.