### PR TITLE
Satisfy updated DDEV add-on maintenance checker rules

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,7 @@
+## Short Summary (TL;DR)
+
+<!-- Required. One or two sentences a reviewer can read at a glance: what this changes, and why. Write it last, but put it here first. If it needs a paragraph, the detail belongs in the sections below. -->
+
 ## The Issue
 
 - Fixes #REPLACE_ME_WITH_RELATED_ISSUE_NUMBER
@@ -13,7 +17,7 @@
 <!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->
 
 ```bash
-ddev add-on get https://github.com/UltraBob/ddev-drupal-code-quality/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
+ddev add-on get UltraBob/ddev-drupal-code-quality --pr REPLACE_ME_WITH_THIS_PR_NUMBER
 ddev restart
 ```
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ on:
     inputs:
       debug_enabled:
         type: boolean
-        description: Debug with tmate
+        description: Enable remote debugging session
         required: false
         default: false
       full_tests:


### PR DESCRIPTION
## Short Summary (TL;DR)

Three text-only edits under `.github/` so the scheduled DDEV add-on update checker passes again. No behaviour change.

## The Issue

- Fixes #66

The checker script is fetched live from ddev.com, and DDEV tightened three rules upstream: the PR template must open with a `## Short Summary (TL;DR)` section, its testing command must use the new `ddev add-on get <owner>/<repo> --pr N` form, and `tests.yml` must not mention tmate. The tmate servers were shut down and `ddev/github-action-add-on-test@v2` already switched to upterm (ddev/github-action-add-on-test#67), so only the copied input label was stale.

## How This PR Solves The Issue

- `PULL_REQUEST_TEMPLATE.md`: add the Short Summary section and switch the manual-testing command to the `--pr` flag.
- `tests.yml`: rename the `debug_enabled` description to the tool-neutral upstream wording, "Enable remote debugging session".

## Manual Testing Instructions

```bash
curl -fsSL https://ddev.com/s/addon-update-checker.sh | bash
```

Should print "All checks passed, no actions needed." Verified locally on this branch.

## Automated Testing Overview

The `maintenance-check` workflow runs the same script on this PR.

## Release/Deployment Notes

None. Once merged, the next scheduled run will pass and the issue can stay closed.